### PR TITLE
Hide nested items of hidden items

### DIFF
--- a/lib/questionnaires/model/src/questionnaire_item_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_item_model.dart
@@ -203,7 +203,8 @@ class QuestionnaireItemModel with Diagnosticable {
 
   /// Is this item hidden?
   bool get isHidden {
-    return (questionnaireItem.extension_
+    return (parent?.isHidden == true) ||
+        (questionnaireItem.extension_
                 ?.extensionOrNull(
                   'http://hl7.org/fhir/StructureDefinition/questionnaire-hidden',
                 )


### PR DESCRIPTION
This PR allows items nested within `type: 'group'` items to be hidden if the parent group itself is already hidden.

Thus, it's only necessary for a group to be declared like:

```
    {
      "extension": [
        {
          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-hidden",
          "valueBoolean": true
        }
      ],
      "type": "group",
      "text": "Hidden Group",
      "item": [
        {
          "type": "string",
          "text": "Hidden question"
        },
        ...
      ]
    }
```

in order to make itself and all of its children hidden.