### PR TITLE
QuestionnaireStepper improvements

### DIFF
--- a/lib/questionnaires/model/item/src/response_node.dart
+++ b/lib/questionnaires/model/item/src/response_node.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 /// Unifies certain aspects of groups and answers.
 abstract class ResponseNode with Diagnosticable, ChangeNotifier {
   final ResponseNode? parentNode;
+  late final ResponseNode? rootNode;
 
   late final String _nodeUid;
 
@@ -13,6 +14,7 @@ abstract class ResponseNode with Diagnosticable, ChangeNotifier {
 
   ResponseNode(this.parentNode) {
     _nodeUid = calculateNodeUid();
+    rootNode = parentNode?.rootNode ?? parentNode;
   }
 
   String calculateNodeUid();

--- a/lib/questionnaires/model/src/questionnaire_response_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_response_model.dart
@@ -770,7 +770,7 @@ class QuestionnaireResponseModel {
   }
 
   /// Items can change, and this should not be cached.
-  Iterable<FillerItemModel> orderedFillerItemModels() {
+  List<FillerItemModel> orderedFillerItemModels() {
     return _fillerItems;
   }
 

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -104,28 +104,29 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                   Expanded(
                     child: Column(
                       children: [
-                        ValueListenableBuilder<Decimal>(
-                          builder: (
-                            BuildContext context,
-                            Decimal value,
-                            Widget? child,
-                          ) {
-                            final scoreString = value.value!.round().toString();
+                        if (QuestionnaireTheme.of(context).showScore)
+                          ValueListenableBuilder<Decimal>(
+                            builder: (
+                              BuildContext context,
+                              Decimal value,
+                              Widget? child,
+                            ) {
+                              final scoreString = value.value!.round().toString();
 
-                            return AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 200),
-                              child: Text(
-                                FDashLocalizations.of(context)
-                                    .aggregationScore(scoreString),
-                                key: ValueKey<String>(scoreString),
-                                style: Theme.of(context).textTheme.headline4,
-                              ),
-                            );
-                          },
-                          valueListenable:
-                              QuestionnaireResponseFiller.of(context)
-                                  .aggregator<TotalScoreAggregator>(),
-                        ),
+                              return AnimatedSwitcher(
+                                duration: const Duration(milliseconds: 200),
+                                child: Text(
+                                  FDashLocalizations.of(context)
+                                      .aggregationScore(scoreString),
+                                  key: ValueKey<String>(scoreString),
+                                  style: Theme.of(context).textTheme.headline4,
+                                ),
+                              );
+                            },
+                            valueListenable:
+                                QuestionnaireResponseFiller.of(context)
+                                    .aggregator<TotalScoreAggregator>(),
+                          ),
                         if (QuestionnaireTheme.of(context).showProgress)
                           const QuestionnaireFillerProgressBar(),
                       ],

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:faiadashu/l10n/l10n.dart';
 import 'package:faiadashu/questionnaires/questionnaires.dart';
 import 'package:faiadashu/resource_provider/resource_provider.dart';
@@ -38,9 +39,6 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
       launchContext: widget.launchContext,
       questionnaireModelDefaults: widget.questionnaireModelDefaults,
       builder: (BuildContext context) {
-        final questionnaireFiller = QuestionnaireResponseFiller.of(context);
-        final itemCount = questionnaireFiller.fillerItemModels.length;
-
         return widget.scaffoldBuilder.build(
           context,
           setStateCallback: (fn) => setState(fn),
@@ -53,10 +51,25 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                     /// [PageView.scrollDirection] defaults to [Axis.horizontal].
                     /// Use [Axis.vertical] to scroll vertically.
                     controller: controller,
-                    itemCount: itemCount,
-                    itemBuilder: (BuildContext context, int index) {
-                      return QuestionnaireResponseFiller.of(context)
-                          .itemFillerAt(index);
+                    itemBuilder: (BuildContext context, int pageIndex) {
+                      final responseFiller = QuestionnaireResponseFiller.of(context);
+
+                      int currentPage = -1;
+                      int rootNodeIndex = -1;
+
+                      final rootNode = responseFiller.fillerItemModels
+                        .firstWhereIndexedOrNull((index, element) {
+                          if (element.displayVisibility != DisplayVisibility.hidden) {
+                            currentPage++;
+                            rootNodeIndex = index;
+                          }
+
+                          return currentPage == pageIndex;
+                        });
+
+                      if (rootNode == null) return null;
+
+                      return responseFiller.itemFillerAt(rootNodeIndex);
                     },
                   ),
                 ),

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -49,6 +49,9 @@ class QuestionnaireThemeData {
   /// Returns whether a progress bar/circle is displayed while filling
   final bool showProgress;
 
+  /// Returns whether the score is displayed while filling (in stepper mode only)
+  final bool showScore;
+
   /// Returns height for text field with and without error text
   double get textFieldHeight => defaultTextFieldHeight;
   static const defaultTextFieldHeight = 72.0;
@@ -89,6 +92,7 @@ class QuestionnaireThemeData {
   const QuestionnaireThemeData({
     this.canSkipQuestions = false,
     this.showProgress = true,
+    this.showScore = true,
     this.autoCompleteThreshold = defaultAutoCompleteThreshold,
     this.horizontalCodingBreakpoint = defaultHorizontalCodingBreakpoint,
     this.maxLinesForTextItem = defaultMaxLinesForTextItem,

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -12,6 +12,11 @@ enum CodingControlPreference {
   expanded,
 }
 
+enum StepperGroupDisplayPreference {
+  separated,
+  grouped,
+}
+
 class QuestionnaireTheme extends InheritedWidget {
   final QuestionnaireThemeData data;
 
@@ -71,6 +76,13 @@ class QuestionnaireThemeData {
   static const defaultCodingControlPreference = CodingControlPreference.compact;
   final CodingControlPreference codingControlPreference;
 
+  static const defaultStepperGroupDisplayPreference = StepperGroupDisplayPreference.separated;
+
+  /// Usable when rendering as QuestionnaireStepperPage only.
+  /// Specifies whether group subitems should show in different steps (default),
+  /// or all at once in the same step.
+  final StepperGroupDisplayPreference stepperGroupDisplayPreference;
+
   final QuestionnaireAnswerFiller Function(AnswerModel, {Key? key})
       createQuestionnaireAnswerFiller;
 
@@ -82,6 +94,7 @@ class QuestionnaireThemeData {
     this.maxLinesForTextItem = defaultMaxLinesForTextItem,
     this.codingControlPreference = defaultCodingControlPreference,
     this.maxItemWidth = defaultMaxItemWidth,
+    this.stepperGroupDisplayPreference = defaultStepperGroupDisplayPreference,
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
   });
 


### PR DESCRIPTION
* Fixes a bug in which `QuestionnaireStepper` shows blank screens for hidden/disabled items.
* Adds a `QuestionnaireTheme.stepperGroupDisplayPreference` setting, which allows showing groups and nested items as a single step, instead of each item in separate steps/pages.
* Adds a `QuestionnaireTheme.showScore` setting, which allows hiding score at the bottom of QuestionnaireStepper views.
* Adds a `onQuestionnaireResponseChanged` callback to `QuestionnaireStepper`, similar to the one in `QuestionnaireScroller`.

For example, to use the new settings in the example app with the `PHQ9 Questionnaire Stepper` questionnaire: 

```dart
              ...
              ListTile(
                title: const Text('PHQ9 Questionnaire Stepper'),
                subtitle: const Text(
                  'Simple choice-based survey with a total score.',
                ),
                onTap: () {
                  Navigator.push(
                    context,
                    MaterialPageRoute(
                      builder: (context) => QuestionnaireTheme(
                        data: const QuestionnaireThemeData(
                          // It is better for a wizard to overtly present all choices on each screen.
                          codingControlPreference:
                              CodingControlPreference.expanded,

                          // New settings here
                          showScore: false,
                          stepperGroupDisplayPreference:
                              StepperGroupDisplayPreference.grouped,
                        ),
                        child: QuestionnaireStepperPage(
                          fhirResourceProvider: AssetResourceProvider.singleton(
                            questionnaireResourceUri,
                            'assets/instruments/phq9_instrument.json', // Replace with preferred Questionnaire
                          ),
                          launchContext: launchContext,
                        ),
                      ),
                    ),
                  );
                },
              ),
              ...
```