### PR TITLE
Preliminary Theming/Layout Support

### DIFF
--- a/lib/questionnaires/view/item/answer/src/attachment_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/attachment_answer_filler.dart
@@ -40,17 +40,14 @@ class _AttachmentInputControl extends AnswerInputControl<AttachmentAnswerModel> 
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.only(top: 8, bottom: 8),
-      child: FhirAttachmentPicker(
-        focusNode: focusNode,
-        enabled: answerModel.isControlEnabled,
-        initialAttachment: answerModel.value,
-        allowedMimeTypes: answerModel.mimeTypes,
-        onChanged: (attachment) => answerModel.value = attachment,
-        decoration: InputDecoration(
-          errorText: answerModel.displayErrorText,
-        ),
+    return FhirAttachmentPicker(
+      focusNode: focusNode,
+      enabled: answerModel.isControlEnabled,
+      initialAttachment: answerModel.value,
+      allowedMimeTypes: answerModel.mimeTypes,
+      onChanged: (attachment) => answerModel.value = attachment,
+      decoration: InputDecoration(
+        errorText: answerModel.displayErrorText,
       ),
     );
   }

--- a/lib/questionnaires/view/item/answer/src/boolean_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/boolean_answer_filler.dart
@@ -42,9 +42,6 @@ class _BooleanInputControl extends AnswerInputControl<BooleanAnswerModel> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(
-          height: 8,
-        ),
         Checkbox(
           focusNode: focusNode,
           value: (answerModel.isTriState)

--- a/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
@@ -294,30 +294,27 @@ class _CodingDropdown extends AnswerInputControl<CodingAnswerModel> {
       }),
     ];
 
-    return Container(
-      padding: const EdgeInsets.only(top: 8.0),
-      child: DropdownButtonFormField<String>(
-        isExpanded: true,
-        value: answerModel.singleSelectionUid,
-        onTap: () {
-          focusNode?.requestFocus();
-        },
-        onChanged: answerModel.isControlEnabled
-            ? (uid) {
-                answerModel.value = OptionsOrString.fromSelectionsAndStrings(
-                  answerModel.selectOption(uid),
-                  answerModel.value?.openStrings,
-                );
-              }
-            : null,
-        focusNode: focusNode,
-        items: dropdownItems,
-        decoration: InputDecoration(
-          // Empty error texts triggers red border, but showing text would result in a duplicate.
-          errorStyle:
-              const TextStyle(height: 0, color: Color.fromARGB(0, 0, 0, 0)),
-          errorText: answerModel.displayErrorText,
-        ),
+    return DropdownButtonFormField<String>(
+      isExpanded: true,
+      value: answerModel.singleSelectionUid,
+      onTap: () {
+        focusNode?.requestFocus();
+      },
+      onChanged: answerModel.isControlEnabled
+          ? (uid) {
+              answerModel.value = OptionsOrString.fromSelectionsAndStrings(
+                answerModel.selectOption(uid),
+                answerModel.value?.openStrings,
+              );
+            }
+          : null,
+      focusNode: focusNode,
+      items: dropdownItems,
+      decoration: InputDecoration(
+        // Empty error texts triggers red border, but showing text would result in a duplicate.
+        errorStyle:
+            const TextStyle(height: 0, color: Color.fromARGB(0, 0, 0, 0)),
+        errorText: answerModel.displayErrorText,
       ),
     );
   }
@@ -495,7 +492,6 @@ class _CodingChoiceDecorator extends StatelessWidget {
                     : answerModel.isControlEnabled
                         ? decoTheme.enabledBorder
                         : decoTheme.disabledBorder,
-            margin: const EdgeInsets.only(top: 8, bottom: 8),
             child: child,
           );
         },
@@ -535,36 +531,33 @@ class _CodingAutoComplete extends AnswerInputControl<CodingAnswerModel> {
     return Focus(
       skipTraversal: true,
       focusNode: focusNode,
-      child: Padding(
-        padding: const EdgeInsets.only(top: 8),
-        child: Autocomplete<CodingAnswerOptionModel>(
-          fieldViewBuilder: _fieldViewBuilder,
-          initialValue: TextEditingValue(
-            text: answerModel.singleSelection?.optionText.plainText ?? '',
-          ),
-          displayStringForOption: (answerOption) =>
-              answerOption.optionText.plainText,
-          optionsBuilder: (TextEditingValue textEditingValue) {
-            if (textEditingValue.text.isEmpty) {
-              return const Iterable<CodingAnswerOptionModel>.empty();
-            }
-
-            return answerModel.answerOptions
-                .where((CodingAnswerOptionModel option) {
-              return option.optionText.plainText
-                  .toLowerCase()
-                  .contains(textEditingValue.text.toLowerCase());
-            });
-          },
-          onSelected: (answerModel.isControlEnabled)
-              ? (CodingAnswerOptionModel selectedOption) {
-                  answerModel.value = OptionsOrString.fromSelectionsAndStrings(
-                    answerModel.selectOption(selectedOption.uid),
-                    answerModel.value?.openStrings,
-                  );
-                }
-              : null,
+      child: Autocomplete<CodingAnswerOptionModel>(
+        fieldViewBuilder: _fieldViewBuilder,
+        initialValue: TextEditingValue(
+          text: answerModel.singleSelection?.optionText.plainText ?? '',
         ),
+        displayStringForOption: (answerOption) =>
+            answerOption.optionText.plainText,
+        optionsBuilder: (TextEditingValue textEditingValue) {
+          if (textEditingValue.text.isEmpty) {
+            return const Iterable<CodingAnswerOptionModel>.empty();
+          }
+
+          return answerModel.answerOptions
+              .where((CodingAnswerOptionModel option) {
+            return option.optionText.plainText
+                .toLowerCase()
+                .contains(textEditingValue.text.toLowerCase());
+          });
+        },
+        onSelected: (answerModel.isControlEnabled)
+            ? (CodingAnswerOptionModel selectedOption) {
+                answerModel.value = OptionsOrString.fromSelectionsAndStrings(
+                  answerModel.selectOption(selectedOption.uid),
+                  answerModel.value?.openStrings,
+                );
+              }
+            : null,
       ),
     );
   }

--- a/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
@@ -45,22 +45,11 @@ class _CodingInputControl extends AnswerInputControl<CodingAnswerModel> {
   Widget build(BuildContext context) {
     final errorText = answerModel.displayErrorText;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildCodingControl(context),
-        if (answerModel.isOptionsOrString) _OpenStringInputControl(answerModel),
-        Container(
-          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16.0),
-          child: Text(
-            errorText ?? '',
-            style: Theme.of(context)
-                .textTheme
-                .caption
-                ?.copyWith(color: Theme.of(context).errorColor),
-          ),
-        ),
-      ],
+    return QuestionnaireTheme.of(context).codingControlLayoutBuilder(
+      context,
+      _buildCodingControl(context),
+      openStringInputControlWidget: answerModel.isOptionsOrString ? _OpenStringInputControl(answerModel) : null,
+      errorText: errorText,
     );
   }
 

--- a/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
@@ -54,28 +54,25 @@ class _DateTimeInputControl extends AnswerInputControl<DateTimeAnswerModel> {
       }[itemType],
     );
 
-    return Container(
-      padding: const EdgeInsets.only(top: 8, bottom: 8),
-      child: FhirDateTimePicker(
-        focusNode: focusNode,
-        enabled: answerModel.isControlEnabled,
-        locale: locale,
-        initialDateTime: initialDate,
-        // TODO: This can be specified through minValue / maxValue
-        firstDate: DateTime(1860),
-        lastDate: DateTime(2050),
-        pickerType: pickerType,
-        decoration: InputDecoration(
-          errorText: answerModel.displayErrorText,
-          errorStyle: (itemModel
-                  .isCalculated) // Force display of error text on calculated item
-              ? TextStyle(
-                  color: Theme.of(context).errorColor,
-                )
-              : null,
-        ),
-        onChanged: (fhirDatetime) => answerModel.value = fhirDatetime,
+    return FhirDateTimePicker(
+      focusNode: focusNode,
+      enabled: answerModel.isControlEnabled,
+      locale: locale,
+      initialDateTime: initialDate,
+      // TODO: This can be specified through minValue / maxValue
+      firstDate: DateTime(1860),
+      lastDate: DateTime(2050),
+      pickerType: pickerType,
+      decoration: InputDecoration(
+        errorText: answerModel.displayErrorText,
+        errorStyle: (itemModel
+                .isCalculated) // Force display of error text on calculated item
+            ? TextStyle(
+                color: Theme.of(context).errorColor,
+              )
+            : null,
       ),
+      onChanged: (fhirDatetime) => answerModel.value = fhirDatetime,
     );
   }
 }

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -117,11 +117,8 @@ class _SliderInputControl extends AnswerInputControl<NumericalAnswerModel> {
               ),
             ),
             if (answerModel.hasUnitChoices)
-              SizedBox(
-                height: 16,
-                child: _UnitDropDown(
-                  answerModel,
-                ),
+              _UnitDropDown(
+                answerModel,
               ),
           ],
         ),
@@ -145,7 +142,6 @@ class _SliderInputControl extends AnswerInputControl<NumericalAnswerModel> {
               const SizedBox(width: 8.0),
             ],
           ),
-        if (hasSliderLabels) const SizedBox(height: 8.0),
       ],
     );
   }
@@ -188,69 +184,58 @@ class _NumberFieldInputControl
       );
     }
 
-    final theme = QuestionnaireTheme.of(context);
-
-    return Container(
-      padding: const EdgeInsets.only(top: 8, bottom: 8),
-      child: SizedBox(
-        height: theme.textFieldHeight,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: TextFormField(
-                focusNode: focusNode,
-                enabled: answerModel.isControlEnabled,
-                controller: editingController,
-                textAlignVertical: TextAlignVertical.center,
-                textAlign: TextAlign.end,
-                decoration: InputDecoration(
-                  errorText: answerModel.displayErrorText,
-                  errorStyle: (itemModel
-                          .isCalculated) // Force display of error text on calculated item
-                      ? TextStyle(
-                          color: Theme.of(context).errorColor,
-                        )
-                      : null,
-                  hintText: answerModel.entryFormat,
-                  prefixIcon: itemModel.isCalculated
-                      ? Icon(
-                          Icons.calculate,
-                          color: (answerModel.displayErrorText != null)
-                              ? Theme.of(context).errorColor
-                              : null,
-                        )
-                      : null,
-                  suffixIcon: (answerModel.hasUnitChoices)
-                      ? SizedBox(
-                          height: 16,
-                          child: _UnitDropDown(
-                            answerModel,
-                          ),
-                        )
-                      : null,
-                ),
-                inputFormatters: [numberInputFormatter],
-                keyboardType: TextInputType.numberWithOptions(
-                  signed: answerModel.minValue < 0,
-                  decimal: answerModel.maxDecimal > 0,
-                ),
-                validator: (itemModel.isCalculated)
-                    ? null
-                    : (inputValue) {
-                        return answerModel.validateInput(inputValue);
-                      },
-                autovalidateMode: (itemModel.isCalculated)
-                    ? AutovalidateMode.disabled
-                    : AutovalidateMode.always,
-                onChanged: (content) {
-                  answerModel.value = answerModel.copyWithTextInput(content);
-                },
-              ),
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: TextFormField(
+            focusNode: focusNode,
+            enabled: answerModel.isControlEnabled,
+            controller: editingController,
+            textAlignVertical: TextAlignVertical.center,
+            textAlign: TextAlign.end,
+            decoration: InputDecoration(
+              errorText: answerModel.displayErrorText,
+              errorStyle: (itemModel
+                      .isCalculated) // Force display of error text on calculated item
+                  ? TextStyle(
+                      color: Theme.of(context).errorColor,
+                    )
+                  : null,
+              hintText: answerModel.entryFormat,
+              prefixIcon: itemModel.isCalculated
+                  ? Icon(
+                      Icons.calculate,
+                      color: (answerModel.displayErrorText != null)
+                          ? Theme.of(context).errorColor
+                          : null,
+                    )
+                  : null,
+              suffixIcon: (answerModel.hasUnitChoices)
+                  ? _UnitDropDown(
+                      answerModel,
+                    )
+                  : null,
             ),
-          ],
+            inputFormatters: [numberInputFormatter],
+            keyboardType: TextInputType.numberWithOptions(
+              signed: answerModel.minValue < 0,
+              decimal: answerModel.maxDecimal > 0,
+            ),
+            validator: (itemModel.isCalculated)
+                ? null
+                : (inputValue) {
+                    return answerModel.validateInput(inputValue);
+                  },
+            autovalidateMode: (itemModel.isCalculated)
+                ? AutovalidateMode.disabled
+                : AutovalidateMode.always,
+            onChanged: (content) {
+              answerModel.value = answerModel.copyWithTextInput(content);
+            },
+          ),
         ),
-      ),
+      ],
     );
   }
 }
@@ -267,7 +252,7 @@ class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
     return answerModel.hasSingleUnitChoice
         ? Container(
             alignment: Alignment.topLeft,
-            padding: const EdgeInsets.only(left: 8, top: 10),
+            padding: const EdgeInsets.only(left: 8),
             width: unitWidth,
             child: Text(
               answerModel.unitChoices.first.localizedDisplay(locale),

--- a/lib/questionnaires/view/item/answer/src/string_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/string_answer_filler.dart
@@ -85,46 +85,38 @@ class _StringAnswerInputControl extends AnswerInputControl<StringAnswerModel> {
       StringAnswerKeyboard.multiline: TextInputType.multiline,
     }[answerModel.keyboard]!;
 
-    final theme = QuestionnaireTheme.of(context);
-
-    return Container(
-      padding: const EdgeInsets.only(top: 8, bottom: 8),
-      child: SizedBox(
-        height: theme.textFieldHeight,
-        child: TextFormField(
-          focusNode: focusNode,
-          enabled: answerModel.isControlEnabled,
-          keyboardType: keyboardType,
-          controller: editingController,
-          maxLines: (qi.type == QuestionnaireItemType.text)
-              ? QuestionnaireTheme.of(context).maxLinesForTextItem
-              : 1,
-          decoration: InputDecoration(
-            errorText: answerModel.displayErrorText,
-            errorStyle: (itemModel
-                    .isCalculated) // Force display of error text on calculated item
-                ? TextStyle(
-                    color: Theme.of(context).errorColor,
-                  )
-                : null,
-            hintText: answerModel.entryFormat,
-            prefixIcon: itemModel.isCalculated
-                ? Icon(
-                    Icons.calculate,
-                    color: (answerModel.displayErrorText != null)
-                        ? Theme.of(context).errorColor
-                        : null,
-                  )
-                : null,
-          ),
-          validator: (inputValue) => answerModel.validateInput(inputValue),
-          autovalidateMode: AutovalidateMode.always,
-          onChanged: (content) {
-            answerModel.value = content;
-          },
-          maxLength: answerModel.maxLength,
-        ),
+    return TextFormField(
+      focusNode: focusNode,
+      enabled: answerModel.isControlEnabled,
+      keyboardType: keyboardType,
+      controller: editingController,
+      maxLines: (qi.type == QuestionnaireItemType.text)
+          ? QuestionnaireTheme.of(context).maxLinesForTextItem
+          : 1,
+      decoration: InputDecoration(
+        errorText: answerModel.displayErrorText,
+        errorStyle: (itemModel
+                .isCalculated) // Force display of error text on calculated item
+            ? TextStyle(
+                color: Theme.of(context).errorColor,
+              )
+            : null,
+        hintText: answerModel.entryFormat,
+        prefixIcon: itemModel.isCalculated
+            ? Icon(
+                Icons.calculate,
+                color: (answerModel.displayErrorText != null)
+                    ? Theme.of(context).errorColor
+                    : null,
+              )
+            : null,
       ),
+      validator: (inputValue) => answerModel.validateInput(inputValue),
+      autovalidateMode: AutovalidateMode.always,
+      onChanged: (content) {
+        answerModel.value = content;
+      },
+      maxLength: answerModel.maxLength,
     );
   }
 }

--- a/lib/questionnaires/view/item/src/display_item.dart
+++ b/lib/questionnaires/view/item/src/display_item.dart
@@ -33,6 +33,7 @@ class _DisplayItemState extends QuestionnaireItemFillerState<DisplayItem> {
                 DisplayVisibility.hidden
             ? QuestionnaireTheme.of(context).displayItemLayoutBuilder(
                 context,
+                widget.fillerItemModel as DisplayItemModel,
                 titleWidget: titleWidget,
               )
             : const SizedBox.shrink();

--- a/lib/questionnaires/view/item/src/display_item.dart
+++ b/lib/questionnaires/view/item/src/display_item.dart
@@ -31,13 +31,9 @@ class _DisplayItemState extends QuestionnaireItemFillerState<DisplayItem> {
       builder: (context, _) {
         return widget.fillerItemModel.displayVisibility !=
                 DisplayVisibility.hidden
-            ? Column(
-                children: [
-                  if (titleWidget != null) titleWidget,
-                  const SizedBox(
-                    height: 16.0,
-                  ),
-                ],
+            ? QuestionnaireTheme.of(context).displayItemLayoutBuilder(
+                context,
+                titleWidget: titleWidget,
               )
             : const SizedBox.shrink();
       },

--- a/lib/questionnaires/view/item/src/group_item.dart
+++ b/lib/questionnaires/view/item/src/group_item.dart
@@ -36,7 +36,7 @@ class _GroupItemState extends ResponseItemFillerState<GroupItem> {
                 DisplayVisibility.hidden
             ? QuestionnaireTheme.of(context).groupItemLayoutBuilder(
                 context,
-                widget.responseItemModel,
+                widget.responseItemModel as GroupItemModel,
                 titleWidget: titleWidget,
                 errorText: errorText,
               )

--- a/lib/questionnaires/view/item/src/group_item.dart
+++ b/lib/questionnaires/view/item/src/group_item.dart
@@ -34,21 +34,11 @@ class _GroupItemState extends ResponseItemFillerState<GroupItem> {
 
         return widget.responseItemModel.displayVisibility !=
                 DisplayVisibility.hidden
-            ? Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (titleWidget != null) titleWidget,
-                  if (errorText != null)
-                    Container(
-                      padding: const EdgeInsets.only(top: 4.0),
-                      child: Text(
-                        errorText,
-                        style: Theme.of(context).textTheme.subtitle1!.copyWith(
-                              color: Theme.of(context).errorColor,
-                            ),
-                      ),
-                    ),
-                ],
+            ? QuestionnaireTheme.of(context).groupItemLayoutBuilder(
+                context,
+                widget.responseItemModel,
+                titleWidget: titleWidget,
+                errorText: errorText,
               )
             : const SizedBox.shrink();
       },

--- a/lib/questionnaires/view/item/src/question_response_item_filler.dart
+++ b/lib/questionnaires/view/item/src/question_response_item_filler.dart
@@ -123,6 +123,7 @@ class QuestionResponseItemFillerState
             focusNode: focusNode,
             child: QuestionnaireTheme.of(context).questionResponseItemLayoutBuilder(
               context,
+              widget.responseItemModel as QuestionItemModel,
               _answerFillerWidget(),
               titleWidget: titleWidget,
               promptTextWidget: _promptTextWidget(context),

--- a/lib/questionnaires/view/item/src/question_response_item_filler.dart
+++ b/lib/questionnaires/view/item/src/question_response_item_filler.dart
@@ -60,15 +60,55 @@ class QuestionResponseItemFillerState
     }
   }
 
+  Widget _answerFillerWidget() {
+    return _HorizontalAnswerFillers(
+      questionResponseItemModel,
+      questionnaireTheme,
+    );
+  }
+
+  Widget? _promptTextWidget(BuildContext context) {
+    final promptText = _promptText;
+    if (promptText == null) return null;
+
+    return Xhtml.fromRenderingString(
+      context,
+      promptText,
+    );
+  }
+
+  Widget? _questionSkipperWidget() {
+    if (questionnaireTheme.canSkipQuestions &&
+      !widget.questionnaireItemModel.isReadOnly &&
+      !widget.questionnaireItemModel.isRequired
+    ) {
+      return Row(
+        children: [
+          Text(
+            FDashLocalizations.of(context)
+                .dataAbsentReasonAskedDeclinedInputLabel,
+          ),
+          Switch(
+            focusNode: _skipSwitchFocusNode,
+            value: questionResponseItemModel.isAskedButDeclined,
+            onChanged: (bool value) {
+              _setDataAbsentReason(
+                value ? dataAbsentReasonAskedButDeclinedCode : null,
+              );
+            },
+          ),
+        ],
+      );
+    }
+
+    return null;
+  }
+
   @override
   Widget build(BuildContext context) {
     _qrimLogger.trace(
       'build ${widget.responseItemModel} hidden: ${widget.responseItemModel.questionnaireItemModel.isHidden}, enabled: ${widget.responseItemModel.isEnabled}',
     );
-
-    final canSkipQuestions = questionnaireTheme.canSkipQuestions;
-
-    final promptText = _promptText;
 
     return AnimatedBuilder(
       animation: widget.responseItemModel,
@@ -81,46 +121,12 @@ class QuestionResponseItemFillerState
               debugDumpFocusTree();
             }, */
             focusNode: focusNode,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (titleWidget != null)
-                  Container(
-                    padding: const EdgeInsets.only(top: 8),
-                    child: titleWidget,
-                  ),
-                if (promptText != null)
-                  Xhtml.fromRenderingString(
-                    context,
-                    promptText,
-                  ),
-                _HorizontalAnswerFillers(
-                  questionResponseItemModel,
-                  questionnaireTheme,
-                ),
-                if (canSkipQuestions &&
-                    !widget.questionnaireItemModel.isReadOnly &&
-                    !widget.questionnaireItemModel.isRequired)
-                  Row(
-                    children: [
-                      Text(
-                        FDashLocalizations.of(context)
-                            .dataAbsentReasonAskedDeclinedInputLabel,
-                      ),
-                      Switch(
-                        focusNode: _skipSwitchFocusNode,
-                        value: questionResponseItemModel.isAskedButDeclined,
-                        onChanged: (bool value) {
-                          _setDataAbsentReason(
-                            value ? dataAbsentReasonAskedButDeclinedCode : null,
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                const SizedBox(height: 8),
-              ],
+            child: QuestionnaireTheme.of(context).questionResponseItemLayoutBuilder(
+              context,
+              _answerFillerWidget(),
+              titleWidget: titleWidget,
+              promptTextWidget: _promptTextWidget(context),
+              questionSkipperWidget: _questionSkipperWidget(),
             ),
           ),
           secondChild: const SizedBox(

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler_title.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler_title.dart
@@ -70,7 +70,6 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
 
     return Container(
       alignment: AlignmentDirectional.centerStart,
-      padding: const EdgeInsets.only(top: 8.0),
       child: Row(
         children: [
           Expanded(

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -201,8 +201,11 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
                                   constraints.maxWidth - twice * edgeInsets,
                                 ),
                           ),
-                          child: QuestionnaireResponseFiller.of(context)
-                              .itemFillerAt(i),
+                          child: QuestionnaireTheme.of(context).scrollerItemBuilder(
+                            context,
+                            QuestionnaireResponseFiller.of(context),
+                            i,
+                          ),
                         ),
                         const Spacer(),
                       ],

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -11,7 +11,6 @@ class QuestionnaireStepper extends StatefulWidget {
   final LaunchContext launchContext;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
   final QuestionnaireModelDefaults questionnaireModelDefaults;
-  final bool showGroupsAsSingleSteps;
 
   final void Function(QuestionnaireResponseModel?)?
       onQuestionnaireResponseChanged;
@@ -22,7 +21,6 @@ class QuestionnaireStepper extends StatefulWidget {
     required this.fhirResourceProvider,
     required this.launchContext,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
-    this.showGroupsAsSingleSteps = false,
     this.onQuestionnaireResponseChanged,
     Key? key,
   }) : super(key: key);

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -1,4 +1,3 @@
-import 'package:collection/collection.dart';
 import 'package:faiadashu/l10n/l10n.dart';
 import 'package:faiadashu/questionnaires/questionnaires.dart';
 import 'package:faiadashu/resource_provider/resource_provider.dart';
@@ -44,9 +43,6 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
   @override
   Widget build(BuildContext context) {
     final controller = PageController();
-    final questionnaireTheme = QuestionnaireTheme.of(context);
-    final showGroupsAsSingleSteps = widget.showGroupsAsSingleSteps
-      || questionnaireTheme.stepperGroupDisplayPreference == StepperGroupDisplayPreference.grouped;
 
     return QuestionnaireResponseFiller(
       locale: widget.locale ?? Localizations.localeOf(context),
@@ -67,15 +63,10 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                     /// Use [Axis.vertical] to scroll vertically.
                     controller: controller,
                     itemBuilder: (BuildContext context, int index) {
-                      final responseFiller = QuestionnaireResponseFiller.of(context);
-                      if (!showGroupsAsSingleSteps) return responseFiller.visibleItemFillerAt(index);
-
-                      final range = responseFiller.itemRangeOfVisibleRootItemAt(index);
-                      if (range[0] < 0) return null;
-
-                      return ListView.builder(
-                        itemCount: range[1] - range[0],
-                        itemBuilder: (context, index) => responseFiller.itemFillerAt(range[0] + index),
+                      return QuestionnaireTheme.of(context).stepperPageItemBuilder(
+                        context,
+                        QuestionnaireResponseFiller.of(context),
+                        index,
                       );
                     },
                   ),

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -56,20 +56,17 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
           child: Column(
             children: [
               Expanded(
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: PageView.builder(
-                    /// [PageView.scrollDirection] defaults to [Axis.horizontal].
-                    /// Use [Axis.vertical] to scroll vertically.
-                    controller: controller,
-                    itemBuilder: (BuildContext context, int index) {
-                      return QuestionnaireTheme.of(context).stepperPageItemBuilder(
-                        context,
-                        QuestionnaireResponseFiller.of(context),
-                        index,
-                      );
-                    },
-                  ),
+                child: PageView.builder(
+                  /// [PageView.scrollDirection] defaults to [Axis.horizontal].
+                  /// Use [Axis.vertical] to scroll vertically.
+                  controller: controller,
+                  itemBuilder: (BuildContext context, int index) {
+                    return QuestionnaireTheme.of(context).stepperPageItemBuilder(
+                      context,
+                      QuestionnaireResponseFiller.of(context),
+                      index,
+                    );
+                  },
                 ),
               ),
               Row(

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -104,6 +104,12 @@ class QuestionnaireThemeData {
     String? errorText,
   }) codingControlLayoutBuilder;
 
+  final Widget? Function(
+    BuildContext context,
+    QuestionnaireFillerData responseFiller,
+    int pageIndex,
+  ) stepperPageItemBuilder;
+
   const QuestionnaireThemeData({
     this.canSkipQuestions = false,
     this.showProgress = true,
@@ -117,6 +123,7 @@ class QuestionnaireThemeData {
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
     this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
     this.codingControlLayoutBuilder = _defaultCodingControlLayoutBuilder,
+    this.stepperPageItemBuilder = _defaultStepperPageItemBuilder,
   });
 
   /// Returns a [QuestionnaireItemFiller] for a given [QuestionnaireResponseFiller].
@@ -308,5 +315,13 @@ class QuestionnaireThemeData {
         ),
       ],
     );
+  }
+
+  static Widget? _defaultStepperPageItemBuilder(
+    BuildContext context,
+    QuestionnaireFillerData responseFiller,
+    int index,
+  ) {
+    return responseFiller.visibleItemFillerAt(index);
   }
 }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -52,10 +52,6 @@ class QuestionnaireThemeData {
   /// Returns whether the score is displayed while filling (in stepper mode only)
   final bool showScore;
 
-  /// Returns height for text field with and without error text
-  final double textFieldHeight;
-  static const defaultTextFieldHeight = 72.0;
-
   static const defaultAutoCompleteThreshold = 10;
 
   /// Coding answers with more than this amount of choices will be shown as auto-complete control
@@ -126,7 +122,6 @@ class QuestionnaireThemeData {
     this.canSkipQuestions = false,
     this.showProgress = true,
     this.showScore = true,
-    this.textFieldHeight = defaultTextFieldHeight,
     this.autoCompleteThreshold = defaultAutoCompleteThreshold,
     this.horizontalCodingBreakpoint = defaultHorizontalCodingBreakpoint,
     this.maxLinesForTextItem = defaultMaxLinesForTextItem,
@@ -299,10 +294,13 @@ class QuestionnaireThemeData {
           ),
         if (promptTextWidget != null)
           promptTextWidget,
-        answerFillerWidget,
+        Container(
+          padding: const EdgeInsets.only(top: 8),
+          child: answerFillerWidget,
+        ),
         if (questionSkipperWidget != null)
           questionSkipperWidget,
-        const SizedBox(height: 8),
+        const SizedBox(height: 16),
       ],
     );
   }
@@ -316,7 +314,11 @@ class QuestionnaireThemeData {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (titleWidget != null) titleWidget,
+        if (titleWidget != null)
+          Container(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: titleWidget,
+          ),
         if (errorText != null)
           Container(
             padding: const EdgeInsets.only(top: 4.0),
@@ -337,10 +339,12 @@ class QuestionnaireThemeData {
   }) {
     return Column(
       children: [
-        if (titleWidget != null) titleWidget,
-        const SizedBox(
-          height: 16.0,
-        ),
+        if (titleWidget != null)
+          Container(
+            padding: const EdgeInsets.only(top: 8.0),
+            child: titleWidget,
+          ),
+        const SizedBox(height: 16.0),
       ],
     );
   }
@@ -356,15 +360,12 @@ class QuestionnaireThemeData {
       children: [
         codingControlWidget,
         if (openStringInputControlWidget != null) openStringInputControlWidget,
-        Container(
-          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16.0),
-          child: Text(
-            errorText ?? '',
-            style: Theme.of(context)
-                .textTheme
-                .caption
-                ?.copyWith(color: Theme.of(context).errorColor),
-          ),
+        if (errorText != null) Text(
+          errorText,
+          style: Theme.of(context)
+              .textTheme
+              .caption
+              ?.copyWith(color: Theme.of(context).errorColor),
         ),
       ],
     );
@@ -375,6 +376,12 @@ class QuestionnaireThemeData {
     QuestionnaireFillerData responseFiller,
     int index,
   ) {
-    return responseFiller.visibleItemFillerAt(index);
+    final itemFiller = responseFiller.visibleItemFillerAt(index);
+    if (itemFiller == null ) return null;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: itemFiller,
+    );
   }
 }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -87,6 +87,7 @@ class QuestionnaireThemeData {
 
   final Widget Function(
     BuildContext context,
+    QuestionItemModel questionItemModel,
     Widget answerFillerWidget, {
     Widget? titleWidget,
     Widget? promptTextWidget,
@@ -95,13 +96,14 @@ class QuestionnaireThemeData {
 
   final Widget Function(
     BuildContext context,
-    ResponseItemModel responseItemModel, {
+    GroupItemModel groupItemModel, {
     Widget? titleWidget,
     String? errorText,
   }) groupItemLayoutBuilder;
 
   final Widget Function(
-    BuildContext context, {
+    BuildContext context,
+    DisplayItemModel displayItemModel, {
     Widget? titleWidget,
   }) displayItemLayoutBuilder;
 
@@ -278,6 +280,7 @@ class QuestionnaireThemeData {
 
   static Widget _defaultQuestionResponseItemLayoutBuilder(
     BuildContext context,
+    QuestionItemModel questionItemModel,
     Widget answerFillerWidget, {
     Widget? titleWidget,
     Widget? promptTextWidget,
@@ -307,7 +310,7 @@ class QuestionnaireThemeData {
 
   static Widget _defaultGroupItemLayoutBuilder(
     BuildContext context,
-    ResponseItemModel responseItemModel, {
+    GroupItemModel groupItemModel, {
     Widget? titleWidget,
     String? errorText,
   }) {
@@ -334,7 +337,8 @@ class QuestionnaireThemeData {
   }
 
   static Widget _defaultDisplayItemLayoutBuilder(
-    BuildContext context,{
+    BuildContext context,
+    DisplayItemModel displayItemModel, {
     Widget? titleWidget,
   }) {
     return Column(

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -85,6 +85,15 @@ class QuestionnaireThemeData {
   final QuestionnaireAnswerFiller Function(AnswerModel, {Key? key})
       createQuestionnaireAnswerFiller;
 
+  /// Builds layouts for question items.
+  ///
+  /// [titleWidget] contains the text of the question, [answerFillerWidget] is the input control
+  /// associated with the corresponding question (textbox, datepicker, etc.).
+  ///
+  /// [promptTextWidget] contains the prompt text content if the question has an itemControl extension
+  /// with `prompt` type.
+  ///
+  /// [questionSkipperWidget] is returned if `QuestionnaireThemeData.canSkipQuestions` is set to true.
   final Widget Function(
     BuildContext context,
     QuestionItemModel questionItemModel,
@@ -94,6 +103,11 @@ class QuestionnaireThemeData {
     Widget? questionSkipperWidget,
   }) questionResponseItemLayoutBuilder;
 
+  /// Builds layouts for group items.
+  ///
+  /// [titleWidget] contains the text of the group.
+  ///
+  /// [errorText] contains any validation errors associated with the group in question.
   final Widget Function(
     BuildContext context,
     GroupItemModel groupItemModel, {
@@ -101,12 +115,22 @@ class QuestionnaireThemeData {
     String? errorText,
   }) groupItemLayoutBuilder;
 
+  /// Builds layouts for display items.
+  ///
+  /// [titleWidget] contains the text of the display item.
   final Widget Function(
     BuildContext context,
     DisplayItemModel displayItemModel, {
     Widget? titleWidget,
   }) displayItemLayoutBuilder;
 
+  /// Builds layouts for the input controls of choice-type items (coding).
+  ///
+  /// [codingControlWidget] is the input control associated with the question.
+  ///
+  /// [openStringInputControlWidget] is returned if the item is of type open-choice.
+  ///
+  /// [errorText] contains any validation errors associated with the question.
   final Widget Function(
     BuildContext context,
     Widget codingControlWidget, {
@@ -114,6 +138,12 @@ class QuestionnaireThemeData {
     String? errorText,
   }) codingControlLayoutBuilder;
 
+  /// Builds layouts for QuestionnaireStepper pages.
+  /// If there are no more pages to show, this method must return `null`.
+  ///
+  /// [responseFiller] contains the state data for the current [QuestionnaireResponseFiller].
+  ///
+  /// [pageIndex] is the index of the page that's being currently built.
   final Widget? Function(
     BuildContext context,
     QuestionnaireFillerData responseFiller,

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -12,11 +12,6 @@ enum CodingControlPreference {
   expanded,
 }
 
-enum StepperGroupDisplayPreference {
-  separated,
-  grouped,
-}
-
 class QuestionnaireTheme extends InheritedWidget {
   final QuestionnaireThemeData data;
 
@@ -74,13 +69,6 @@ class QuestionnaireThemeData {
 
   static const defaultCodingControlPreference = CodingControlPreference.compact;
   final CodingControlPreference codingControlPreference;
-
-  static const defaultStepperGroupDisplayPreference = StepperGroupDisplayPreference.separated;
-
-  /// Usable when rendering as QuestionnaireStepperPage only.
-  /// Specifies whether group subitems should show in different steps (default),
-  /// or all at once in the same step.
-  final StepperGroupDisplayPreference stepperGroupDisplayPreference;
 
   final QuestionnaireAnswerFiller Function(AnswerModel, {Key? key})
       createQuestionnaireAnswerFiller;
@@ -159,7 +147,6 @@ class QuestionnaireThemeData {
     this.maxLinesForTextItem = defaultMaxLinesForTextItem,
     this.codingControlPreference = defaultCodingControlPreference,
     this.maxItemWidth = defaultMaxItemWidth,
-    this.stepperGroupDisplayPreference = defaultStepperGroupDisplayPreference,
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
     this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
     this.groupItemLayoutBuilder = _defaultGroupItemLayoutBuilder,

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -105,6 +105,11 @@ class QuestionnaireThemeData {
   }) groupItemLayoutBuilder;
 
   final Widget Function(
+    BuildContext context, {
+    Widget? titleWidget,
+  }) displayItemLayoutBuilder;
+
+  final Widget Function(
     BuildContext context,
     Widget codingControlWidget, {
     Widget? openStringInputControlWidget,
@@ -131,6 +136,7 @@ class QuestionnaireThemeData {
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
     this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
     this.groupItemLayoutBuilder = _defaultGroupItemLayoutBuilder,
+    this.displayItemLayoutBuilder = _defaultDisplayItemLayoutBuilder,
     this.codingControlLayoutBuilder = _defaultCodingControlLayoutBuilder,
     this.stepperPageItemBuilder = _defaultStepperPageItemBuilder,
   });
@@ -321,6 +327,20 @@ class QuestionnaireThemeData {
                   ),
             ),
           ),
+      ],
+    );
+  }
+
+  static Widget _defaultDisplayItemLayoutBuilder(
+    BuildContext context,{
+    Widget? titleWidget,
+  }) {
+    return Column(
+      children: [
+        if (titleWidget != null) titleWidget,
+        const SizedBox(
+          height: 16.0,
+        ),
       ],
     );
   }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -53,7 +53,7 @@ class QuestionnaireThemeData {
   final bool showScore;
 
   /// Returns height for text field with and without error text
-  double get textFieldHeight => defaultTextFieldHeight;
+  final double textFieldHeight;
   static const defaultTextFieldHeight = 72.0;
 
   static const defaultAutoCompleteThreshold = 10;
@@ -121,6 +121,7 @@ class QuestionnaireThemeData {
     this.canSkipQuestions = false,
     this.showProgress = true,
     this.showScore = true,
+    this.textFieldHeight = defaultTextFieldHeight,
     this.autoCompleteThreshold = defaultAutoCompleteThreshold,
     this.horizontalCodingBreakpoint = defaultHorizontalCodingBreakpoint,
     this.maxLinesForTextItem = defaultMaxLinesForTextItem,

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -126,6 +126,17 @@ class QuestionnaireThemeData {
     String? errorText,
   }) codingControlLayoutBuilder;
 
+  /// Builds layouts for QuestionnaireScroller items.
+  ///
+  /// [responseFiller] contains the state data for the current [QuestionnaireResponseFiller].
+  ///
+  /// [itemIndex] is the index of the form item that's being currently built.
+  final Widget? Function(
+    BuildContext context,
+    QuestionnaireFillerData responseFiller,
+    int itemIndex,
+  ) scrollerItemBuilder;
+
   /// Builds layouts for QuestionnaireStepper pages.
   /// If there are no more pages to show, this method must return `null`.
   ///
@@ -152,6 +163,7 @@ class QuestionnaireThemeData {
     this.groupItemLayoutBuilder = _defaultGroupItemLayoutBuilder,
     this.displayItemLayoutBuilder = _defaultDisplayItemLayoutBuilder,
     this.codingControlLayoutBuilder = _defaultCodingControlLayoutBuilder,
+    this.scrollerItemBuilder = _defaultScrollerItemBuilder,
     this.stepperPageItemBuilder = _defaultStepperPageItemBuilder,
   });
 
@@ -390,6 +402,14 @@ class QuestionnaireThemeData {
         ),
       ],
     );
+  }
+
+  static Widget? _defaultScrollerItemBuilder(
+    BuildContext context,
+    QuestionnaireFillerData responseFiller,
+    int index,
+  ) {
+    return responseFiller.itemFillerAt(index);
   }
 
   static Widget? _defaultStepperPageItemBuilder(

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -89,6 +89,14 @@ class QuestionnaireThemeData {
   final QuestionnaireAnswerFiller Function(AnswerModel, {Key? key})
       createQuestionnaireAnswerFiller;
 
+  final Widget Function(
+    BuildContext context,
+    Widget answerFillerWidget, {
+    Widget? titleWidget,
+    Widget? promptTextWidget,
+    Widget? questionSkipperWidget,
+  }) questionResponseItemLayoutBuilder;
+
   const QuestionnaireThemeData({
     this.canSkipQuestions = false,
     this.showProgress = true,
@@ -100,6 +108,7 @@ class QuestionnaireThemeData {
     this.maxItemWidth = defaultMaxItemWidth,
     this.stepperGroupDisplayPreference = defaultStepperGroupDisplayPreference,
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
+    this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
   });
 
   /// Returns a [QuestionnaireItemFiller] for a given [QuestionnaireResponseFiller].
@@ -238,6 +247,32 @@ class QuestionnaireThemeData {
           icon: const Icon(Icons.add),
         ),
         const SizedBox(height: 8.0),
+      ],
+    );
+  }
+
+  static Widget _defaultQuestionResponseItemLayoutBuilder(
+    BuildContext context,
+    Widget answerFillerWidget, {
+    Widget? titleWidget,
+    Widget? promptTextWidget,
+    Widget? questionSkipperWidget,
+  }) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (titleWidget != null)
+          Container(
+            padding: const EdgeInsets.only(top: 8),
+            child: titleWidget,
+          ),
+        if (promptTextWidget != null)
+          promptTextWidget,
+        answerFillerWidget,
+        if (questionSkipperWidget != null)
+          questionSkipperWidget,
+        const SizedBox(height: 8),
       ],
     );
   }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -97,6 +97,13 @@ class QuestionnaireThemeData {
     Widget? questionSkipperWidget,
   }) questionResponseItemLayoutBuilder;
 
+  final Widget Function(
+    BuildContext context,
+    Widget codingControlWidget, {
+    Widget? openStringInputControlWidget,
+    String? errorText,
+  }) codingControlLayoutBuilder;
+
   const QuestionnaireThemeData({
     this.canSkipQuestions = false,
     this.showProgress = true,
@@ -109,6 +116,7 @@ class QuestionnaireThemeData {
     this.stepperGroupDisplayPreference = defaultStepperGroupDisplayPreference,
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
     this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
+    this.codingControlLayoutBuilder = _defaultCodingControlLayoutBuilder,
   });
 
   /// Returns a [QuestionnaireItemFiller] for a given [QuestionnaireResponseFiller].
@@ -273,6 +281,31 @@ class QuestionnaireThemeData {
         if (questionSkipperWidget != null)
           questionSkipperWidget,
         const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  static Widget _defaultCodingControlLayoutBuilder(
+    BuildContext context,
+    Widget codingControlWidget, {
+    Widget? openStringInputControlWidget,
+    String? errorText,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        codingControlWidget,
+        if (openStringInputControlWidget != null) openStringInputControlWidget,
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16.0),
+          child: Text(
+            errorText ?? '',
+            style: Theme.of(context)
+                .textTheme
+                .caption
+                ?.copyWith(color: Theme.of(context).errorColor),
+          ),
+        ),
       ],
     );
   }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -99,6 +99,13 @@ class QuestionnaireThemeData {
 
   final Widget Function(
     BuildContext context,
+    ResponseItemModel responseItemModel, {
+    Widget? titleWidget,
+    String? errorText,
+  }) groupItemLayoutBuilder;
+
+  final Widget Function(
+    BuildContext context,
     Widget codingControlWidget, {
     Widget? openStringInputControlWidget,
     String? errorText,
@@ -122,6 +129,7 @@ class QuestionnaireThemeData {
     this.stepperGroupDisplayPreference = defaultStepperGroupDisplayPreference,
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
     this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
+    this.groupItemLayoutBuilder = _defaultGroupItemLayoutBuilder,
     this.codingControlLayoutBuilder = _defaultCodingControlLayoutBuilder,
     this.stepperPageItemBuilder = _defaultStepperPageItemBuilder,
   });
@@ -288,6 +296,30 @@ class QuestionnaireThemeData {
         if (questionSkipperWidget != null)
           questionSkipperWidget,
         const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  static Widget _defaultGroupItemLayoutBuilder(
+    BuildContext context,
+    ResponseItemModel responseItemModel, {
+    Widget? titleWidget,
+    String? errorText,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (titleWidget != null) titleWidget,
+        if (errorText != null)
+          Container(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: Text(
+              errorText,
+              style: Theme.of(context).textTheme.subtitle1!.copyWith(
+                    color: Theme.of(context).errorColor,
+                  ),
+            ),
+          ),
       ],
     );
   }


### PR DESCRIPTION
This PR introduces multiples changes to allow customizing layouts in the app.

The idea is to have a set of default layout builder functions that can be overridden in `QuestionnaireTheme`.

These changes try to keep paddings and other UI-related requirements within these functions as much as possible, so that these can be easily overridden afterwards.