### PR TITLE
Fix time filler data population on re-rendering

### DIFF
--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -58,6 +58,15 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
     super.dispose();
   }
 
+  String _formatDateTime(FhirDateTime? value, Locale locale) {
+    final dateTime = value?.valueDateTime;
+    if (value == null || dateTime == null) return '';
+
+    return (widget.pickerType == Time)
+      ? DateFormat.jm(locale.toString()).format(dateTime)
+      : value.format(locale);
+  }
+
   Future<void> _showPicker(Locale locale) async {
     DateTime dateTime = DateTime(1970);
 
@@ -110,9 +119,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
           : DateTimePrecision.FULL,
     );
     setState(() {
-      _dateTimeFieldController.text = (widget.pickerType == Time)
-          ? DateFormat.jm(locale.toString()).format(dateTime)
-          : fhirDateTime.format(locale);
+      _dateTimeFieldController.text = _formatDateTime(fhirDateTime, locale);
     });
     _dateTimeValue = fhirDateTime;
     widget.onChanged?.call(fhirDateTime);
@@ -124,7 +131,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
 
     // There is no Locale in initState.
     if (!_fieldInitialized) {
-      _dateTimeFieldController.text = _dateTimeValue?.format(locale) ?? '';
+      _dateTimeFieldController.text = _formatDateTime(_dateTimeValue, locale);
       _fieldInitialized = true;
     }
 

--- a/lib/questionnaires/model/item/answer/src/datetime_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/datetime_answer_model.dart
@@ -80,7 +80,14 @@ class DateTimeAnswerModel extends AnswerModel<FhirDateTime, FhirDateTime> {
 
   @override
   void populate(QuestionnaireResponseAnswer answer) {
-    value = answer.valueDateTime ??
-        ((answer.valueDate != null) ? FhirDateTime(answer.valueDate) : null);
+    // NOTE: Model should probably be populated based on QuestionnaireItemType
+    value = answer.valueDateTime ?? (
+      (answer.valueDate != null)
+      ? FhirDateTime(answer.valueDate)
+      : (answer.valueTime != null)
+      // TODO: Find a better way to convert Time values to FhirDateTime
+      ? FhirDateTime('1970-01-01T${answer.valueTime}')
+      : null
+    );
   }
 }

--- a/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
@@ -43,8 +43,7 @@ class _DateTimeInputControl extends AnswerInputControl<DateTimeAnswerModel> {
   Widget build(BuildContext context) {
     final itemType = qi.type;
 
-    final initialDate =
-        (itemType != QuestionnaireItemType.time) ? answerModel.value : null;
+    final initialDate = answerModel.value;
 
     final pickerType = ArgumentError.checkNotNull(
       const {


### PR DESCRIPTION
This PR introduces the following changes:

* Refactors date/time formatting in `date_time_picker.dart` into a single implementation.
* Fixes time filler answers not being repopulated after rerendering or loading previously saved responses. 

Details about how to reproduce the issue are in https://github.com/sujrd/faiadashu/issues/27