### PR TITLE
Expose PageController of QuestionnaireStepper

### DIFF
--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -1,0 +1,105 @@
+import 'package:faiadashu/faiadashu.dart';
+import 'package:flutter/material.dart';
+
+class CustomQuestionnaireStepperPage extends StatefulWidget {
+  final Locale? locale;
+  final FhirResourceProvider fhirResourceProvider;
+  final LaunchContext launchContext;
+  final QuestionnaireModelDefaults questionnaireModelDefaults;
+
+  const CustomQuestionnaireStepperPage({
+    super.key,
+    this.locale,
+    required this.fhirResourceProvider,
+    required this.launchContext,
+    this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
+  });
+
+  @override
+  State<CustomQuestionnaireStepperPage> createState() =>
+      _CustomQuestionnaireStepperPageState();
+}
+
+class _CustomQuestionnaireStepperPageState
+    extends State<CustomQuestionnaireStepperPage> {
+  final _pageController = PageController();
+  int _currentIndex = 0;
+  QuestionnaireResponseModel? _questionnaireResponseModel;
+
+  void _nextPage() {
+    final item = _questionnaireResponseModel
+        ?.orderedResponseItemModels()
+        .elementAt(_currentIndex);
+    if (item?.validate(notifyListeners: true) == null) {
+      _pageController.nextPage(
+        curve: Curves.easeIn,
+        duration: const Duration(milliseconds: 250),
+      );
+    }
+  }
+
+  void _prevPage() {
+    _pageController.previousPage(
+      curve: Curves.easeIn,
+      duration: const Duration(milliseconds: 250),
+    );
+  }
+
+  void _onPageChanged(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+
+  bool _hasReachedLastPage() {
+    final totalPage =
+        _questionnaireResponseModel?.orderedFillerItemModels().length ?? 0;
+    return _currentIndex == totalPage - 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        color: Colors.white,
+        child: Column(
+          children: [
+            Expanded(
+              child: QuestionnaireStepper(
+                scaffoldBuilder:
+                    const DefaultQuestionnairePageScaffoldBuilder(),
+                fhirResourceProvider: widget.fhirResourceProvider,
+                launchContext: widget.launchContext,
+                pageController: _pageController,
+                onQuestionnaireResponseChanged: (questionnaireResponseModel) {
+                  _questionnaireResponseModel = questionnaireResponseModel;
+                },
+                onPageChanged: _onPageChanged,
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  onPressed: _prevPage,
+                ),
+                if (_hasReachedLastPage())
+                  const Text(
+                    "Reached Last Page",
+                    style: TextStyle(
+                      fontSize: 12.0,
+                    ),
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.arrow_forward),
+                  onPressed: _nextPage,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -53,7 +53,7 @@ class _CustomQuestionnaireStepperPageState
 
   bool _hasReachedLastPage() {
     final totalPage =
-        _questionnaireResponseModel?.orderedFillerItemModels().length ?? 0;
+        _questionnaireResponseModel?.orderedQuestionItemModels().length ?? 0;
     return _currentIndex == totalPage - 1;
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:faiadashu/faiadashu.dart';
 import 'package:faiadashu/logging/logging.dart' as fdashlog;
 import 'package:faiadashu_example/about_page.dart';
 import 'package:faiadashu_example/cherry_blossom_theme.dart';
+import 'package:faiadashu_example/custom_questionnaire_stepper_page.dart';
 import 'package:faiadashu_example/disclaimer_page.dart';
 import 'package:faiadashu_example/observation_page.dart';
 import 'package:faiadashu_example/primitive_page.dart';
@@ -331,6 +332,33 @@ class _HomePageState extends State<HomePage> {
                           fhirResourceProvider: AssetResourceProvider.singleton(
                             questionnaireResourceUri,
                             'assets/instruments/phq9_instrument.json',
+                          ),
+                          launchContext: launchContext,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                title: const Text('Custom Questionnaire Stepper Page'),
+                subtitle: const Text(
+                  'Cardiac risk scoring survey with customized buttons.',
+                ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => QuestionnaireTheme(
+                        data: const QuestionnaireThemeData(
+                          // It is better for a wizard to overtly present all choices on each screen.
+                          codingControlPreference:
+                              CodingControlPreference.expanded,
+                        ),
+                        child: CustomQuestionnaireStepperPage(
+                          fhirResourceProvider: AssetResourceProvider.singleton(
+                            questionnaireResourceUri,
+                            'assets/instruments/framingham-hcdc.json',
                           ),
                           launchContext: launchContext,
                         ),

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -11,9 +11,11 @@ class QuestionnaireStepper extends StatefulWidget {
   final LaunchContext launchContext;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
   final QuestionnaireModelDefaults questionnaireModelDefaults;
+  final PageController? pageController;
 
   final void Function(QuestionnaireResponseModel?)?
       onQuestionnaireResponseChanged;
+  final void Function(int)? onPageChanged;
 
   const QuestionnaireStepper({
     this.locale,
@@ -22,6 +24,8 @@ class QuestionnaireStepper extends StatefulWidget {
     required this.launchContext,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
     this.onQuestionnaireResponseChanged,
+    this.onPageChanged,
+    this.pageController,
     Key? key,
   }) : super(key: key);
 
@@ -40,7 +44,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
 
   @override
   Widget build(BuildContext context) {
-    final controller = PageController();
+    final controller = widget.pageController ?? PageController();
 
     return QuestionnaireResponseFiller(
       locale: widget.locale ?? Localizations.localeOf(context),
@@ -58,6 +62,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                   /// [PageView.scrollDirection] defaults to [Axis.horizontal].
                   /// Use [Axis.vertical] to scroll vertically.
                   controller: controller,
+                  onPageChanged: widget.onPageChanged,
                   itemBuilder: (BuildContext context, int index) {
                     return QuestionnaireTheme.of(context).stepperPageItemBuilder(
                       context,
@@ -65,18 +70,22 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                       index,
                     );
                   },
+                  physics: widget.pageController != null
+                      ? const NeverScrollableScrollPhysics()
+                      : null,
                 ),
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  IconButton(
-                    icon: const Icon(Icons.arrow_back),
-                    onPressed: () => controller.previousPage(
-                      curve: Curves.easeIn,
-                      duration: const Duration(milliseconds: 250),
+                  if (widget.pageController == null)
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: () => controller.previousPage(
+                        curve: Curves.easeIn,
+                        duration: const Duration(milliseconds: 250),
+                      ),
                     ),
-                  ),
                   Expanded(
                     child: Column(
                       children: [
@@ -108,13 +117,14 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                       ],
                     ),
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.arrow_forward),
-                    onPressed: () => controller.nextPage(
-                      curve: Curves.easeIn,
-                      duration: const Duration(milliseconds: 250),
+                  if (widget.pageController == null)
+                    IconButton(
+                      icon: const Icon(Icons.arrow_forward),
+                      onPressed: () => controller.nextPage(
+                        curve: Curves.easeIn,
+                        duration: const Duration(milliseconds: 250),
+                      ),
                     ),
-                  ),
                 ],
               ),
             ],


### PR DESCRIPTION
This PR accepts the following parameters when building a QuestionnareStepper

- `void onPageChanged(int)`: This will be used for the parent to know when the page is changed
- `PageController`: This will be used so the parent controller can control the page view, e.g. next or previous page.

I added `CustomQuestionnaireStepperPage`  as a PoC. 