### PR TITLE
Support unitOption extension

### DIFF
--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -159,6 +159,14 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
         context: qi.linkId,
       );
     }
+
+    qi.extension_
+      ?.whereExtensionIs('http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption')
+      ?.forEach((extension) {
+        final coding = extension.valueCoding;
+        if (coding == null) return;
+        _units[keyForUnitChoice(coding)] = coding;
+      });
   }
 
   @override

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -232,7 +232,10 @@ class _NumberFieldInputControl
                 : AutovalidateMode.always,
             onChanged: (content) {
               answerModel.value = answerModel.copyWithTextInput(content);
-              if (answerModel.hasSingleUnitChoice) {
+              if (answerModel.hasUnitChoices && !answerModel.hasUnit) {
+                // Fix unit not being set properly when value changes if:
+                // - hasSingleUnitChoice = true (no dropdown shown), or
+                // - user has not interacted with the unit dropdown.
                 answerModel.value = answerModel.copyWithUnit(answerModel.unitChoices.first.code?.value);
               }
             },
@@ -267,7 +270,7 @@ class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
             width: unitWidth,
             child: DropdownButtonHideUnderline(
               child: DropdownButton<String>(
-                value: answerModel.keyOfUnit,
+                value: answerModel.keyOfUnit ?? answerModel.unitChoices.first.code?.value,
                 hint: const NullDashText(),
                 onChanged: (answerModel.isControlEnabled)
                     ? (String? newValue) {
@@ -275,7 +278,6 @@ class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
                       }
                     : null,
                 items: [
-                  const DropdownMenuItem<String>(child: NullDashText()),
                   ...answerModel.unitChoices
                       .map<DropdownMenuItem<String>>((Coding value) {
                     return DropdownMenuItem<String>(

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -231,13 +231,19 @@ class _NumberFieldInputControl
                 ? AutovalidateMode.disabled
                 : AutovalidateMode.always,
             onChanged: (content) {
-              answerModel.value = answerModel.copyWithTextInput(content);
+              Quantity? value = answerModel.copyWithTextInput(content);
               if (answerModel.hasUnitChoices && !answerModel.hasUnit) {
                 // Fix unit not being set properly when value changes if:
                 // - hasSingleUnitChoice = true (no dropdown shown), or
                 // - user has not interacted with the unit dropdown.
-                answerModel.value = answerModel.copyWithUnit(answerModel.unitChoices.first.code?.value);
+                value = answerModel
+                  .copyWithUnit(answerModel.unitChoices.first.code?.value)
+                  ?.copyWith(
+                    value: value?.value,
+                    extension_: value?.extension_,
+                  );
               }
+              answerModel.value = value;
             },
           ),
         ),

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -251,7 +251,7 @@ class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
 
     return answerModel.hasSingleUnitChoice
         ? Container(
-            alignment: Alignment.topLeft,
+            alignment: Alignment.centerLeft,
             padding: const EdgeInsets.only(left: 8),
             width: unitWidth,
             child: Text(

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -232,6 +232,9 @@ class _NumberFieldInputControl
                 : AutovalidateMode.always,
             onChanged: (content) {
               answerModel.value = answerModel.copyWithTextInput(content);
+              if (answerModel.hasSingleUnitChoice) {
+                answerModel.value = answerModel.copyWithUnit(answerModel.unitChoices.first.code?.value);
+              }
             },
           ),
         ),


### PR DESCRIPTION
This PR addresses the following:

* Adds support for the `unitOption` extension to show the unit selector in quantity items that have it.
* Fixes vertical position of field units when there's only a single unitOption (no dropdown).
* Fixes a bug in which units would not be set in the response for quantity items/questions with a single unit option.
* Behavior changes:
  * First unit is now selected by default when there's no answer to a quantity question item.
  * Empty units cannot be selected.