### PR TITLE
Allow customizing time/date picker entry modes via QuestionnaireTheme

### DIFF
--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -1,4 +1,5 @@
 import 'package:faiadashu/fhir_types/fhir_types.dart';
+import 'package:faiadashu/questionnaires/view/src/questionnaire_theme.dart';
 import 'package:fhir/r4.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -73,6 +74,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
     if (widget.pickerType != Time) {
       final date = await showDatePicker(
         initialDate: _dateTimeValue?.value ?? DateTime.now(),
+        initialEntryMode: QuestionnaireTheme.of(context).datePickerEntryMode,
         firstDate: widget.firstDate,
         lastDate: widget.lastDate,
         locale: locale,
@@ -89,6 +91,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
       final time = await showTimePicker(
         initialTime:
             TimeOfDay.fromDateTime(_dateTimeValue?.value ?? DateTime.now()),
+        initialEntryMode: QuestionnaireTheme.of(context).timePickerEntryMode,
         context: context,
         builder: (context, child) {
           return Localizations.override(

--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -1,5 +1,4 @@
 import 'package:faiadashu/fhir_types/fhir_types.dart';
-import 'package:faiadashu/questionnaires/view/src/questionnaire_theme.dart';
 import 'package:fhir/r4.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -16,6 +15,8 @@ class FhirDateTimePicker extends StatefulWidget {
   final DateTime lastDate;
   final FhirDateTime? initialDateTime;
   final Type pickerType;
+  final DatePickerEntryMode datePickerEntryMode;
+  final TimePickerEntryMode timePickerEntryMode;
   final InputDecoration? decoration;
   final FocusNode? focusNode;
   final bool enabled;
@@ -26,6 +27,8 @@ class FhirDateTimePicker extends StatefulWidget {
     required this.firstDate,
     required this.lastDate,
     required this.pickerType,
+    this.datePickerEntryMode = DatePickerEntryMode.calendar,
+    this.timePickerEntryMode = TimePickerEntryMode.dial,
     this.decoration,
     this.onChanged,
     this.locale,
@@ -74,7 +77,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
     if (widget.pickerType != Time) {
       final date = await showDatePicker(
         initialDate: _dateTimeValue?.value ?? DateTime.now(),
-        initialEntryMode: QuestionnaireTheme.of(context).datePickerEntryMode,
+        initialEntryMode: widget.datePickerEntryMode,
         firstDate: widget.firstDate,
         lastDate: widget.lastDate,
         locale: locale,
@@ -91,7 +94,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
       final time = await showTimePicker(
         initialTime:
             TimeOfDay.fromDateTime(_dateTimeValue?.value ?? DateTime.now()),
-        initialEntryMode: QuestionnaireTheme.of(context).timePickerEntryMode,
+        initialEntryMode: widget.timePickerEntryMode,
         context: context,
         builder: (context, child) {
           return Localizations.override(

--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -48,6 +48,15 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
   bool _fieldInitialized = false;
   final _clearFocusNode = FocusNode(skipTraversal: true);
 
+  // All 24h TimeOFDayFormats as specified in:
+  // https://api.flutter.dev/flutter/material/TimeOfDayFormat.html
+  static const timeOfDay24hFormats = {
+    TimeOfDayFormat.HH_colon_mm,
+    TimeOfDayFormat.HH_dot_mm,
+    TimeOfDayFormat.frenchCanadian,
+    TimeOfDayFormat.H_colon_mm,
+  };
+
   @override
   void initState() {
     super.initState();
@@ -100,7 +109,22 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
           return Localizations.override(
             context: context,
             locale: locale,
-            child: child,
+            child: Builder(
+              // Get new BuildContext with overridden locale
+              builder: (context) {
+                // Get time of day format of current locale
+                final timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat();
+                return MediaQuery(
+                  data: MediaQuery.of(context).copyWith(
+                    // Workaround for time picker validation bug in `input` mode with locales specifying a 24h TimeOfDayFormat.
+                    // - https://github.com/sujrd/faiadashu/pull/32#issuecomment-1678639964
+                    // - https://github.com/flutter/flutter/issues/85527
+                    alwaysUse24HourFormat: timeOfDay24hFormats.contains(timeOfDayFormat),
+                  ),
+                  child: child!,
+                );
+              },
+            ),
           );
         },
       );

--- a/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
@@ -62,6 +62,8 @@ class _DateTimeInputControl extends AnswerInputControl<DateTimeAnswerModel> {
       firstDate: DateTime(1860),
       lastDate: DateTime(2050),
       pickerType: pickerType,
+      datePickerEntryMode: QuestionnaireTheme.of(context).datePickerEntryMode,
+      timePickerEntryMode: QuestionnaireTheme.of(context).timePickerEntryMode,
       decoration: InputDecoration(
         errorText: answerModel.displayErrorText,
         errorStyle: (itemModel

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -67,6 +67,16 @@ class QuestionnaireThemeData {
   /// They will not use more width, even if the display is wider.
   final double maxItemWidth;
 
+  /// Mode of date entry method for the date picker dialog for date and dateTime items.
+  ///
+  /// Possible Values: https://api.flutter.dev/flutter/material/DatePickerEntryMode.html
+  final DatePickerEntryMode datePickerEntryMode;
+
+  /// Interactive input mode of the time picker dialog for dateTime and time items.
+  ///
+  /// Possible Values: https://api.flutter.dev/flutter/material/TimePickerEntryMode.html
+  final TimePickerEntryMode timePickerEntryMode;
+
   static const defaultCodingControlPreference = CodingControlPreference.compact;
   final CodingControlPreference codingControlPreference;
 
@@ -158,6 +168,8 @@ class QuestionnaireThemeData {
     this.maxLinesForTextItem = defaultMaxLinesForTextItem,
     this.codingControlPreference = defaultCodingControlPreference,
     this.maxItemWidth = defaultMaxItemWidth,
+    this.datePickerEntryMode = DatePickerEntryMode.calendar,
+    this.timePickerEntryMode = TimePickerEntryMode.dial,
     this.createQuestionnaireAnswerFiller = _createDefaultAnswerFiller,
     this.questionResponseItemLayoutBuilder = _defaultQuestionResponseItemLayoutBuilder,
     this.groupItemLayoutBuilder = _defaultGroupItemLayoutBuilder,


### PR DESCRIPTION
Allows setting `showDatePicker` and `showTimePicker`'s `initialEntryMode` property from `QuestionnaireTheme`.