### PR TITLE
Introduce onLastPageUpdated in QuestionnaireStepper

### DIFF
--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -24,6 +24,7 @@ class _CustomQuestionnaireStepperPageState
     extends State<CustomQuestionnaireStepperPage> {
   final _pageController = PageController();
   int _currentIndex = 0;
+  bool _hasReachedLastPage = false;
   QuestionnaireResponseModel? _questionnaireResponseModel;
 
   void _nextPage() {
@@ -51,12 +52,6 @@ class _CustomQuestionnaireStepperPageState
     });
   }
 
-  bool _hasReachedLastPage() {
-    final totalPage =
-        _questionnaireResponseModel?.orderedQuestionItemModels().length ?? 0;
-    return _currentIndex == totalPage - 1;
-  }
-
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -75,6 +70,9 @@ class _CustomQuestionnaireStepperPageState
                   _questionnaireResponseModel = questionnaireResponseModel;
                 },
                 onPageChanged: _onPageChanged,
+                onLastPageUpdated: (bool hasReachedLastPage) {
+                  _hasReachedLastPage = hasReachedLastPage;
+                },
               ),
             ),
             Row(
@@ -84,7 +82,7 @@ class _CustomQuestionnaireStepperPageState
                   icon: const Icon(Icons.arrow_back),
                   onPressed: _prevPage,
                 ),
-                if (_hasReachedLastPage())
+                if (_hasReachedLastPage)
                   const Text(
                     "Reached Last Page",
                     style: TextStyle(

--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -1,4 +1,5 @@
 import 'package:faiadashu/faiadashu.dart';
+import 'package:faiadashu/questionnaires/view/src/questionnaire_stepper_page_view.dart';
 import 'package:flutter/material.dart';
 
 class CustomQuestionnaireStepperPage extends StatefulWidget {
@@ -22,7 +23,7 @@ class CustomQuestionnaireStepperPage extends StatefulWidget {
 
 class _CustomQuestionnaireStepperPageState
     extends State<CustomQuestionnaireStepperPage> {
-  final _pageController = PageController();
+  final _controller = QuestionnaireStepperPageViewController();
   bool _hasReachedLastPage = false;
   QuestionnaireResponseModel? _questionnaireResponseModel;
   QuestionnaireItemFiller? _questionnaireItemFiller;
@@ -46,16 +47,10 @@ class _CustomQuestionnaireStepperPageState
   }
 
   void _navigateToNextPage() {
-    _pageController.nextPage(
-      curve: Curves.easeIn,
-      duration: const Duration(milliseconds: 250),
-    );
+    _controller.nextPage();
   }
   void _prevPage() {
-    _pageController.previousPage(
-      curve: Curves.easeIn,
-      duration: const Duration(milliseconds: 250),
-    );
+    _controller.previousPage();
   }
 
   void _onPageChanged(int index) {
@@ -75,7 +70,7 @@ class _CustomQuestionnaireStepperPageState
                     const DefaultQuestionnairePageScaffoldBuilder(),
                 fhirResourceProvider: widget.fhirResourceProvider,
                 launchContext: widget.launchContext,
-                pageController: _pageController,
+                controller: _controller,
                 onQuestionnaireResponseChanged: (questionnaireResponseModel) {
                   _questionnaireResponseModel = questionnaireResponseModel;
                 },

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -97,8 +97,8 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                   controller: controller,
                   onPageChanged: _handleChangedPage,
                   itemBuilder: (BuildContext context, int index) {
-                    return QuestionnaireTheme.of(context).stepperPageItemBuilder(
                     _itemBuilderContext = context;
+                    return QuestionnaireTheme.of(context).stepperPageItemBuilder(
                       context,
                       QuestionnaireResponseFiller.of(context),
                       index,

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -40,9 +40,13 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
   QuestionnaireResponseModel? _questionnaireResponseModel;
   bool _isLoaded = false;
   bool _lastPageState = false;
+  int? _currentIndex;
 
   void _handleChangedQuestionnaireResponse() {
     widget.onQuestionnaireResponseChanged?.call(_questionnaireResponseModel);
+    if (_currentIndex != null) {
+      _checkAndUpdatePageState(_currentIndex!);
+    }
   }
 
   bool _hasReachedLastPage(int index) {
@@ -65,6 +69,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
   void _handleChangedPage(int index) {
     _checkAndUpdatePageState(index);
     widget.onPageChanged?.call(index);
+    _currentIndex = index;
   }
 
   @override

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -17,6 +17,7 @@ class QuestionnaireStepper extends StatefulWidget {
       onQuestionnaireResponseChanged;
   final void Function(int)? onPageChanged;
   final void Function(bool)? onLastPageUpdated;
+  final void Function(QuestionnaireItemFiller?)? onVisibleItemUpdated;
 
   const QuestionnaireStepper({
     this.locale,
@@ -27,6 +28,7 @@ class QuestionnaireStepper extends StatefulWidget {
     this.onQuestionnaireResponseChanged,
     this.onPageChanged,
     this.onLastPageUpdated,
+    this.onVisibleItemUpdated,
     this.pageController,
     Key? key,
   }) : super(key: key);
@@ -75,7 +77,26 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
     }
   }
 
+  /// Updates the currently visible item based on the provided index.
+  ///
+  /// This ensures that the parent context knows which item is visible and can perform any
+  /// necessary actions or updates related to that item.
+  void _updateVisibleItem(int index) {
+    if (_itemBuilderContext == null) {
+      return;
+    }
+    final responseFiller = QuestionnaireResponseFiller.of(_itemBuilderContext!);
+
+    widget.onVisibleItemUpdated?.call(responseFiller.visibleItemFillerAt(index));
+  }
+
+  /// Manages tasks related to page index changes.
+  ///
+  /// This function is called when the user navigates to a different page.
+  /// It updates the visible item, checks the state of the last page, notifies listeners
+  /// of the change, and updates the current index.
   void _handleChangedPage(int index) {
+    _updateVisibleItem(index);
     _checkAndUpdatePageState(index);
     widget.onPageChanged?.call(index);
     _currentIndex = index;

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -1,5 +1,6 @@
 import 'package:faiadashu/l10n/l10n.dart';
 import 'package:faiadashu/questionnaires/questionnaires.dart';
+import 'package:faiadashu/questionnaires/view/src/questionnaire_stepper_page_view.dart';
 import 'package:faiadashu/resource_provider/resource_provider.dart';
 import 'package:fhir/r4.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +12,7 @@ class QuestionnaireStepper extends StatefulWidget {
   final LaunchContext launchContext;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
   final QuestionnaireModelDefaults questionnaireModelDefaults;
-  final PageController? pageController;
+  final QuestionnaireStepperPageViewController? controller;
 
   final void Function(QuestionnaireResponseModel?)?
       onQuestionnaireResponseChanged;
@@ -29,7 +30,7 @@ class QuestionnaireStepper extends StatefulWidget {
     this.onPageChanged,
     this.onLastPageUpdated,
     this.onVisibleItemUpdated,
-    this.pageController,
+    this.controller,
     Key? key,
   }) : super(key: key);
 
@@ -38,38 +39,27 @@ class QuestionnaireStepper extends StatefulWidget {
 }
 
 class QuestionnaireStepperState extends State<QuestionnaireStepper> {
-  BuildContext? _itemBuilderContext;
   QuestionnaireResponseModel? _questionnaireResponseModel;
+  QuestionnaireStepperPageViewController? _controller;
   bool _isLoaded = false;
   bool _lastPageState = false;
-  int? _currentIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? QuestionnaireStepperPageViewController();
+  }
 
   /// Notifies listeners when there are changes in the questionnaire response.
   void _handleChangedQuestionnaireResponse() {
     widget.onQuestionnaireResponseChanged?.call(_questionnaireResponseModel);
-    if (_currentIndex != null) {
-      _checkAndUpdatePageState(_currentIndex!);
-    }
-  }
-
-  /// Determines if the given index corresponds to the last page.
-  bool _hasReachedLastPage(int index) {
-    if (_itemBuilderContext == null) {
-      return false;
-    }
-    /// By checking the next item from the item builder, it verifies whether we're on the last page.
-    /// If there's no item for the next index, then we've reached the last page.
-    return QuestionnaireTheme.of(_itemBuilderContext!).stepperPageItemBuilder(
-          _itemBuilderContext!,
-          QuestionnaireResponseFiller.of(_itemBuilderContext!),
-          index + 1,
-        ) ==
-        null;
+    // The last page can change based on user responses.
+    _checkAndUpdatePageState();
   }
 
   /// Checks the current page status and updates the last page state accordingly.
-  void _checkAndUpdatePageState(int index) {
-    final currentState = _hasReachedLastPage(index);
+  void _checkAndUpdatePageState({bool? state}) {
+    final currentState = state ?? _controller?.hasReachedLastPage() ?? false;
     /// If the current state differs from the last known page state, listeners are notified.
     if (currentState != _lastPageState) {
       widget.onLastPageUpdated?.call(currentState);
@@ -77,35 +67,8 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
     }
   }
 
-  /// Updates the currently visible item based on the provided index.
-  ///
-  /// This ensures that the parent context knows which item is visible and can perform any
-  /// necessary actions or updates related to that item.
-  void _updateVisibleItem(int index) {
-    if (_itemBuilderContext == null) {
-      return;
-    }
-    final responseFiller = QuestionnaireResponseFiller.of(_itemBuilderContext!);
-
-    widget.onVisibleItemUpdated?.call(responseFiller.visibleItemFillerAt(index));
-  }
-
-  /// Manages tasks related to page index changes.
-  ///
-  /// This function is called when the user navigates to a different page.
-  /// It updates the visible item, checks the state of the last page, notifies listeners
-  /// of the change, and updates the current index.
-  void _handleChangedPage(int index) {
-    _updateVisibleItem(index);
-    _checkAndUpdatePageState(index);
-    widget.onPageChanged?.call(index);
-    _currentIndex = index;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final controller = widget.pageController ?? PageController();
-
     return QuestionnaireResponseFiller(
       locale: widget.locale ?? Localizations.localeOf(context),
       fhirResourceProvider: widget.fhirResourceProvider,
@@ -118,38 +81,22 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
           child: Column(
             children: [
               Expanded(
-                child: PageView.builder(
-                  /// [PageView.scrollDirection] defaults to [Axis.horizontal].
-                  /// Use [Axis.vertical] to scroll vertically.
-                  controller: controller,
-                  onPageChanged: _handleChangedPage,
-                  itemBuilder: (BuildContext context, int index) {
-                    // Store the current context of the item builder.
-                    // This is done so that we can access this context outside the builder.
-                    _itemBuilderContext = context;
-                    // Update the state or properties associated with the currently visible item.
-                    _updateVisibleItem(index);
-                    return QuestionnaireTheme.of(context).stepperPageItemBuilder(
-                      context,
-                      QuestionnaireResponseFiller.of(context),
-                      index,
-                    );
+                child: QuestionnaireStepperPageView(
+                  controller: _controller,
+                  onPageChanged: widget.onPageChanged,
+                  onVisibleItemUpdated: widget.onVisibleItemUpdated,
+                  onLastPageUpdated: (state) {
+                    _checkAndUpdatePageState(state: state);
                   },
-                  physics: widget.pageController != null
-                      ? const NeverScrollableScrollPhysics()
-                      : null,
                 ),
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  if (widget.pageController == null)
+                  if (widget.controller == null)
                     IconButton(
                       icon: const Icon(Icons.arrow_back),
-                      onPressed: () => controller.previousPage(
-                        curve: Curves.easeIn,
-                        duration: const Duration(milliseconds: 250),
-                      ),
+                      onPressed: () => widget.controller?.previousPage(),
                     ),
                   Expanded(
                     child: Column(
@@ -182,13 +129,10 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                       ],
                     ),
                   ),
-                  if (widget.pageController == null)
+                  if (widget.controller == null)
                     IconButton(
                       icon: const Icon(Icons.arrow_forward),
-                      onPressed: () => controller.nextPage(
-                        curve: Curves.easeIn,
-                        duration: const Duration(milliseconds: 250),
-                      ),
+                      onPressed: () => widget.controller?.nextPage(),
                     ),
                 ],
               ),

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -42,6 +42,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
   bool _lastPageState = false;
   int? _currentIndex;
 
+  /// Notifies listeners when there are changes in the questionnaire response.
   void _handleChangedQuestionnaireResponse() {
     widget.onQuestionnaireResponseChanged?.call(_questionnaireResponseModel);
     if (_currentIndex != null) {
@@ -49,10 +50,13 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
     }
   }
 
+  /// Determines if the given index corresponds to the last page.
   bool _hasReachedLastPage(int index) {
     if (_itemBuilderContext == null) {
       return false;
     }
+    /// By checking the next item from the item builder, it verifies whether we're on the last page.
+    /// If there's no item for the next index, then we've reached the last page.
     return QuestionnaireTheme.of(_itemBuilderContext!).stepperPageItemBuilder(
           _itemBuilderContext!,
           QuestionnaireResponseFiller.of(_itemBuilderContext!),
@@ -61,8 +65,10 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
         null;
   }
 
+  /// Checks the current page status and updates the last page state accordingly.
   void _checkAndUpdatePageState(int index) {
     final currentState = _hasReachedLastPage(index);
+    /// If the current state differs from the last known page state, listeners are notified.
     if (currentState != _lastPageState) {
       widget.onLastPageUpdated?.call(currentState);
       _lastPageState = currentState;
@@ -97,7 +103,11 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                   controller: controller,
                   onPageChanged: _handleChangedPage,
                   itemBuilder: (BuildContext context, int index) {
+                    // Store the current context of the item builder.
+                    // This is done so that we can access this context outside the builder.
                     _itemBuilderContext = context;
+                    // Update the state or properties associated with the currently visible item.
+                    _updateVisibleItem(index);
                     return QuestionnaireTheme.of(context).stepperPageItemBuilder(
                       context,
                       QuestionnaireResponseFiller.of(context),

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -50,12 +50,15 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
   }
 
   bool _hasReachedLastPage(int index) {
-    if (_itemBuilderContext != null) {
-      return QuestionnaireResponseFiller.of(_itemBuilderContext!)
-              .visibleItemFillerAt(index + 1) ==
-          null;
+    if (_itemBuilderContext == null) {
+      return false;
     }
-    return false;
+    return QuestionnaireTheme.of(_itemBuilderContext!).stepperPageItemBuilder(
+          _itemBuilderContext!,
+          QuestionnaireResponseFiller.of(_itemBuilderContext!),
+          index + 1,
+        ) ==
+        null;
   }
 
   void _checkAndUpdatePageState(int index) {
@@ -95,6 +98,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                   onPageChanged: _handleChangedPage,
                   itemBuilder: (BuildContext context, int index) {
                     return QuestionnaireTheme.of(context).stepperPageItemBuilder(
+                    _itemBuilderContext = context;
                       context,
                       QuestionnaireResponseFiller.of(context),
                       index,

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -1,0 +1,149 @@
+import 'package:faiadashu/questionnaires/view/item/src/questionnaire_item_filler.dart';
+import 'package:faiadashu/questionnaires/view/src/questionnaire_filler.dart';
+import 'package:faiadashu/questionnaires/view/src/questionnaire_theme.dart';
+import 'package:flutter/material.dart';
+
+/// A specialized `PageView` designed to display a series of questions
+/// in a step-by-step format.
+///
+/// [QuestionnaireStepperPageView] seamlessly integrates with [QuestionnaireStepperPageViewController]
+/// to parent widget navigating the page view, or retrieve information related the view.
+class QuestionnaireStepperPageView extends StatefulWidget {
+  final QuestionnaireStepperPageViewController? controller;
+  final ValueChanged<int>? onPageChanged;
+  final Function(bool)? onLastPageUpdated;
+  final void Function(QuestionnaireItemFiller?)? onVisibleItemUpdated;
+
+  QuestionnaireStepperPageView({
+    this.controller,
+    this.onPageChanged,
+    this.onLastPageUpdated,
+    this.onVisibleItemUpdated,
+  });
+
+  @override
+  _QuestionnaireStepperPageViewState createState() =>
+      _QuestionnaireStepperPageViewState();
+}
+
+class _QuestionnaireStepperPageViewState extends State<QuestionnaireStepperPageView> {
+  PageController _pageController = PageController();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller?._attach(this);
+  }
+
+  /// Determines if the given index corresponds to the last page.
+  bool _hasReachedLastPage() {
+    final currentPage = _pageController.page!.round();
+    final themeData = QuestionnaireTheme.of(context);
+    final fillerData = QuestionnaireResponseFiller.of(context);
+
+    /// By checking the next item from the item builder, it verifies whether we're on the last page.
+    /// If there's no item for the next index, then we've reached the last page.
+    return themeData.stepperQuestionnaireItemFiller(
+      fillerData,
+      currentPage + 1,
+    ) == null;
+  }
+
+  /// Updates the currently visible item based on the provided index.
+  ///
+  /// This ensures that the parent context knows which item is visible and can perform any
+  /// necessary actions or updates related to that item.
+  void _updateVisibleItem(int index) {
+    final responseFiller = QuestionnaireResponseFiller.of(context);
+
+    widget.onVisibleItemUpdated?.call(responseFiller.visibleItemFillerAt(index));
+  }
+
+  /// Manages tasks related to page index changes.
+  ///
+  /// This function is called when the user navigates to a different page.
+  /// It updates the visible item, checks the state of the last page, notifies listeners
+  /// of the change, and updates the current index.
+  void _handleChangedPage(int index) {
+    _updateVisibleItem(index);
+    widget.onPageChanged?.call(index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PageView.builder(
+      /// [PageView.scrollDirection] defaults to [Axis.horizontal].
+      /// Use [Axis.vertical] to scroll vertically.
+      controller: _pageController,
+      onPageChanged: _handleChangedPage,
+      itemBuilder: (BuildContext context, int index) {
+        final responseFillerData = QuestionnaireResponseFiller.of(context);
+
+        final data = QuestionnaireTheme.of(context)
+            .stepperQuestionnaireItemFiller(responseFillerData, index);
+
+        _updateVisibleItem(index);
+        if (data == null) return null;
+
+        return QuestionnaireTheme.of(context).stepperPageItemBuilder(
+          context,
+          data,
+        );
+      },
+      physics: widget.controller != null
+          ? const NeverScrollableScrollPhysics()
+          : null,
+    );
+  }
+
+  @override
+  void dispose() {
+    widget.controller?._detach();
+    super.dispose();
+  }
+}
+
+/// A controller designed to be used with [QuestionnaireStepperPageView] to
+/// manage the display and flow of questionnaire steps.
+///
+/// It provides methods and properties to control the form.
+class QuestionnaireStepperPageViewController {
+  _QuestionnaireStepperPageViewState? _state;
+
+  /// Attaches the provided state to this controller.
+  /// This internal method is used to establish a connection between the
+  /// controller and the `_QuestionnaireStepperPageViewState`.
+  void _attach(_QuestionnaireStepperPageViewState state) {
+    _state = state;
+  }
+
+  /// Detaches the state from this controller.
+  /// This is usually called when the associated `QuestionnaireStepperPageView`
+  /// is getting disposed to avoid any potential memory leaks or unintended behaviors.
+  void _detach() {
+    _state = null;
+  }
+
+  /// Advances to the next page in the `QuestionnaireStepperPageView`.
+  void nextPage() {
+    _state?._pageController.nextPage(
+      curve: Curves.easeIn,
+      duration: const Duration(milliseconds: 250),
+    );
+  }
+
+  /// Back to the previous page in the `QuestionnaireStepperPageView`.
+  void previousPage() {
+    _state?._pageController.previousPage(
+      curve: Curves.easeIn,
+      duration: const Duration(milliseconds: 250),
+    );
+  }
+
+  /// Checks if the current page in the `QuestionnaireStepperPageView` is the last one.
+  ///
+  /// Returns `true` if the last page has been reached, otherwise returns `false`.
+  bool hasReachedLastPage() {
+    return _state?._hasReachedLastPage() ?? false;
+  }
+}

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -56,7 +56,10 @@ class _QuestionnaireStepperPageViewState extends State<QuestionnaireStepperPageV
   void _updateVisibleItem(int index) {
     final responseFiller = QuestionnaireResponseFiller.of(context);
 
-    widget.onVisibleItemUpdated?.call(responseFiller.visibleItemFillerAt(index));
+    final data = QuestionnaireTheme.of(context)
+            .stepperQuestionnaireItemFiller(responseFiller, index);
+            
+    widget.onVisibleItemUpdated?.call(data);
   }
 
   /// Manages tasks related to page index changes.

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -57,16 +57,15 @@ class _QuestionnaireStepperPageViewState extends State<QuestionnaireStepperPageV
     final responseFiller = QuestionnaireResponseFiller.of(context);
 
     final data = QuestionnaireTheme.of(context)
-            .stepperQuestionnaireItemFiller(responseFiller, index);
-            
+        .stepperQuestionnaireItemFiller(responseFiller, index);
+
     widget.onVisibleItemUpdated?.call(data);
   }
 
   /// Manages tasks related to page index changes.
   ///
   /// This function is called when the user navigates to a different page.
-  /// It updates the visible item, checks the state of the last page, notifies listeners
-  /// of the change, and updates the current index.
+  /// It updates the visible item, and notifies listeners of the change.
   void _handleChangedPage(int index) {
     _updateVisibleItem(index);
     widget.onPageChanged?.call(index);

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -143,15 +143,15 @@ class QuestionnaireThemeData {
   ///
   /// [pageIndex] is the index of the page that's being currently built.
   final QuestionnaireItemFiller? Function(
-      QuestionnaireFillerData responseFiller,
-      int pageIndex,
+    QuestionnaireFillerData responseFiller,
+    int pageIndex,
   ) stepperQuestionnaireItemFiller;
 
   /// Builds layouts for QuestionnaireStepper pages.
   /// If there are no more pages to show, this method must return `null`.
   ///
   /// [itemFiller] contains [QuestionnaireItemFiller] to be rendered.
-  final Widget? Function(
+  final Widget Function(
     BuildContext context,
     QuestionnaireItemFiller itemFiller,
   ) stepperPageItemBuilder;
@@ -421,18 +421,18 @@ class QuestionnaireThemeData {
   }
 
   static QuestionnaireItemFiller? _defaultStepperQuestionnaireItemFiller(
-      QuestionnaireFillerData responseFiller,
-      int index,
+    QuestionnaireFillerData responseFiller,
+    int index,
   ) {
     final itemFiller = responseFiller.visibleItemFillerAt(index);
-    if (itemFiller == null ) return null;
+    if (itemFiller == null) return null;
 
     return itemFiller;
   }
 
-  static Widget? _defaultStepperPageItemBuilder(
-      BuildContext context,
-      QuestionnaireItemFiller itemFiller,
+  static Widget _defaultStepperPageItemBuilder(
+    BuildContext context,
+    QuestionnaireItemFiller itemFiller,
   ) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -137,16 +137,23 @@ class QuestionnaireThemeData {
     int itemIndex,
   ) scrollerItemBuilder;
 
-  /// Builds layouts for QuestionnaireStepper pages.
-  /// If there are no more pages to show, this method must return `null`.
+  /// Get [QuestionnaireItemFiller] for a specific page.
   ///
   /// [responseFiller] contains the state data for the current [QuestionnaireResponseFiller].
   ///
   /// [pageIndex] is the index of the page that's being currently built.
+  final QuestionnaireItemFiller? Function(
+      QuestionnaireFillerData responseFiller,
+      int pageIndex,
+  ) stepperQuestionnaireItemFiller;
+
+  /// Builds layouts for QuestionnaireStepper pages.
+  /// If there are no more pages to show, this method must return `null`.
+  ///
+  /// [itemFiller] contains [QuestionnaireItemFiller] to be rendered.
   final Widget? Function(
     BuildContext context,
-    QuestionnaireFillerData responseFiller,
-    int pageIndex,
+    QuestionnaireItemFiller itemFiller,
   ) stepperPageItemBuilder;
 
   const QuestionnaireThemeData({
@@ -164,6 +171,7 @@ class QuestionnaireThemeData {
     this.displayItemLayoutBuilder = _defaultDisplayItemLayoutBuilder,
     this.codingControlLayoutBuilder = _defaultCodingControlLayoutBuilder,
     this.scrollerItemBuilder = _defaultScrollerItemBuilder,
+    this.stepperQuestionnaireItemFiller = _defaultStepperQuestionnaireItemFiller,
     this.stepperPageItemBuilder = _defaultStepperPageItemBuilder,
   });
 
@@ -412,14 +420,20 @@ class QuestionnaireThemeData {
     return responseFiller.itemFillerAt(index);
   }
 
-  static Widget? _defaultStepperPageItemBuilder(
-    BuildContext context,
-    QuestionnaireFillerData responseFiller,
-    int index,
+  static QuestionnaireItemFiller? _defaultStepperQuestionnaireItemFiller(
+      QuestionnaireFillerData responseFiller,
+      int index,
   ) {
     final itemFiller = responseFiller.visibleItemFillerAt(index);
     if (itemFiller == null ) return null;
 
+    return itemFiller;
+  }
+
+  static Widget? _defaultStepperPageItemBuilder(
+      BuildContext context,
+      QuestionnaireItemFiller itemFiller,
+  ) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: itemFiller,


### PR DESCRIPTION
Basically, this PR introduces `onLastPageUpdated` in QuestionnaireStepper, so parent widget can know when the last page is really reached.

We check the state when the page index is changed and the questionnaire response is updated.
______

In our internal app, we need a way to know exactly which QuestionnaireItemFiller is currently shown. `onVisibleItemUpdated`  callback is added in `QuestionnaireStepper`. This will be called for the following scenarios:
- page index is changed.
- page view item is updated.