### PR TITLE
Support questionnaire-unit extension

### DIFF
--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -15,10 +15,11 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
   late final double _minValue;
   late final double _maxValue;
   late final int _maxDecimal;
-  late final Coding? _questionnaireUnit;
   late final NumberFormat _numberFormat;
   late final double? _sliderStepValue;
   late final int? _sliderDivisions;
+  bool get questionnaireUnitDisplayVisible => questionnaireResponseModel
+      .questionnaireModel.questionnaireModelDefaults.questionnaireUnitDisplayVisible;
 
   RenderingString? _upperSliderLabel;
   RenderingString? _lowerSliderLabel;
@@ -34,7 +35,6 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
   double get minValue => _minValue;
   double get maxValue => _maxValue;
   int get maxDecimal => _maxDecimal;
-  Coding? get questionnaireUnit => _questionnaireUnit;
   NumberFormat get numberFormat => _numberFormat;
 
   late final Map<String, Coding> _units;
@@ -169,8 +169,11 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
         if (coding == null) return;
         _units[keyForUnitChoice(coding)] = coding;
       });
-    final questionnaireUnit = qi.extension_?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/questionnaire-unit')?.valueCoding;
-    if (questionnaireUnit != null) _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
+
+    if(questionnaireUnitDisplayVisible) {
+      final questionnaireUnit = qi.extension_?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/questionnaire-unit')?.valueCoding;
+      if (questionnaireUnit != null) _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
+    }
   }
 
   @override

--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -15,6 +15,7 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
   late final double _minValue;
   late final double _maxValue;
   late final int _maxDecimal;
+  late final Coding? _questionnaireUnit;
   late final NumberFormat _numberFormat;
   late final double? _sliderStepValue;
   late final int? _sliderDivisions;
@@ -33,6 +34,7 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
   double get minValue => _minValue;
   double get maxValue => _maxValue;
   int get maxDecimal => _maxDecimal;
+  Coding? get questionnaireUnit => _questionnaireUnit;
   NumberFormat get numberFormat => _numberFormat;
 
   late final Map<String, Coding> _units;
@@ -167,6 +169,8 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
         if (coding == null) return;
         _units[keyForUnitChoice(coding)] = coding;
       });
+    final questionnaireUnit = qi.extension_?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/questionnaire-unit')?.valueCoding;
+    if (questionnaireUnit != null) _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
   }
 
   @override

--- a/lib/questionnaires/model/src/questionnaire_model_defaults.dart
+++ b/lib/questionnaires/model/src/questionnaire_model_defaults.dart
@@ -27,7 +27,9 @@ class QuestionnaireModelDefaults {
   /// Boolean items will be tri-state if [true], or bi-state if [false].
   final bool booleanTriState;
 
-  /// For integer and decimal questionnaire item types it shows the questionnaire unit display.
+  /// For integer and decimal questionnaire item types containing a `questionnaire-unit` extension, 
+  /// it displays the corresponding unit in the input field, in a similar manner to quantity items with
+  /// `unitOption` extensions.
   final bool questionnaireUnitDisplayVisible;
 
   /// Returns a prefix, starting with 1, that provides the number

--- a/lib/questionnaires/model/src/questionnaire_model_defaults.dart
+++ b/lib/questionnaires/model/src/questionnaire_model_defaults.dart
@@ -27,6 +27,9 @@ class QuestionnaireModelDefaults {
   /// Boolean items will be tri-state if [true], or bi-state if [false].
   final bool booleanTriState;
 
+  /// For integer and decimal questionnaire item types it shows the questionnaire unit display.
+  final bool questionnaireUnitDisplayVisible;
+
   /// Returns a prefix, starting with 1, that provides the number
   /// of the [QuestionItemModel] within the ordered sequence of [QuestionItemModels].
   ///
@@ -62,5 +65,6 @@ class QuestionnaireModelDefaults {
     this.disabledDisplay = QuestionnaireDisabledDisplay.hidden,
     this.implicitNullOption = true,
     this.booleanTriState = false,
+    this.questionnaireUnitDisplayVisible = false,
   });
 }


### PR DESCRIPTION
Example of how it shows:

![Screenshot 2023-08-17 at 9 30 59](https://github.com/sujrd/faiadashu/assets/18192927/2b1e1a13-4ea5-476f-b3b6-bd5fe1eca9aa)

I could either use code or display, I think code is more appropiate for this implementation.