### PR TITLE
Change behavior of questionnaire-unit to work as defined in R5

### DIFF
--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -18,8 +18,6 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
   late final NumberFormat _numberFormat;
   late final double? _sliderStepValue;
   late final int? _sliderDivisions;
-  bool get questionnaireUnitDisplayVisible => questionnaireResponseModel
-      .questionnaireModel.questionnaireModelDefaults.questionnaireUnitDisplayVisible;
 
   RenderingString? _upperSliderLabel;
   RenderingString? _lowerSliderLabel;
@@ -170,10 +168,9 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
         _units[keyForUnitChoice(coding)] = coding;
       });
 
-    if(questionnaireUnitDisplayVisible) {
-      final questionnaireUnit = qi.extension_?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/questionnaire-unit')?.valueCoding;
-      if (questionnaireUnit != null) _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
-    }
+    // Using updated usage for questionnaire-unit in R5 (http://hl7.org/fhir/extensions/StructureDefinition-questionnaire-unit.html)
+    final questionnaireUnit = qi.extension_?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/questionnaire-unit')?.valueCoding;
+    if (questionnaireUnit != null && questionnaireUnit.display != null) _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
   }
 
   @override

--- a/lib/questionnaires/model/src/questionnaire_model_defaults.dart
+++ b/lib/questionnaires/model/src/questionnaire_model_defaults.dart
@@ -27,11 +27,6 @@ class QuestionnaireModelDefaults {
   /// Boolean items will be tri-state if [true], or bi-state if [false].
   final bool booleanTriState;
 
-  /// For integer and decimal questionnaire item types containing a `questionnaire-unit` extension, 
-  /// it displays the corresponding unit in the input field, in a similar manner to quantity items with
-  /// `unitOption` extensions.
-  final bool questionnaireUnitDisplayVisible;
-
   /// Returns a prefix, starting with 1, that provides the number
   /// of the [QuestionItemModel] within the ordered sequence of [QuestionItemModels].
   ///
@@ -67,6 +62,5 @@ class QuestionnaireModelDefaults {
     this.disabledDisplay = QuestionnaireDisabledDisplay.hidden,
     this.implicitNullOption = true,
     this.booleanTriState = false,
-    this.questionnaireUnitDisplayVisible = false,
   });
 }


### PR DESCRIPTION
Shows unit `display` in `questionnaire-unit` extension if present.