### PR TITLE
Fix population of datetimes with TZ info

### DIFF
--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -77,7 +77,7 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
 
     return (widget.pickerType == Time)
       ? DateFormat.jm(locale.toString()).format(dateTime)
-      : value.format(locale);
+      : value.format(locale, withTimeZone: widget.pickerType == FhirDateTime);
   }
 
   Future<void> _showPicker(Locale locale) async {

--- a/lib/fhir_types/src/fhir_types_extensions.dart
+++ b/lib/fhir_types/src/fhir_types_extensions.dart
@@ -41,7 +41,7 @@ extension FDashDateExtension on Date {
 }
 
 extension FDashDateTimeExtension on FhirDateTime {
-  String format(Locale locale, {String defaultText = ''}) {
+  String format(Locale locale, {String defaultText = '', bool withTimeZone = false}) {
     final localeCode = locale.toString();
     final DateFormat dateFormat;
     final japanese = locale.languageCode == 'ja';
@@ -70,7 +70,14 @@ extension FDashDateTimeExtension on FhirDateTime {
         break;
     }
 
-    return dateFormat.format(value!);
+    // Dart only supports UTC or local times, even if the value is parsed from a
+    // datetime string with time zone info.
+    final localDateTime = value!.toLocal();
+    final formattedValue = dateFormat.format(localDateTime);
+
+    return withTimeZone
+      ? '$formattedValue (${localDateTime.timeZoneName})'
+      : formattedValue;
   }
 }
 


### PR DESCRIPTION
The problem is that, in any of these scenarios:
* Setting an initial value for a datetime field with timezone other than local.
* Loading a QuestionnaireResponse with a datetime response in timezone other than local.

The value itself will be auto converted to UTC, and displayed in such a way, which may be confusing.

The current PR converts datetimes to local before displaying them and shows the TZ info as well.
Unfortunately, Dart cannot handle timezones other than UTC or local (https://stackoverflow.com/a/52325454), so we cannot show the datetime in the original timezone.