### PR TITLE
Fix maxDecimalPlaces behavior

### DIFF
--- a/example/assets/instruments/sdc_demo.json
+++ b/example/assets/instruments/sdc_demo.json
@@ -326,7 +326,33 @@
       ],
       "linkId": "100000",
       "type": "decimal",
-      "text": "Enter your weight in kg"
+      "text": "Enter your weight in kg (max 2 decimal places)"
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/minValue",
+          "valueDecimal": 1
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
+          "valueDecimal": 100
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/maxDecimalPlaces",
+          "valueInteger": 0
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+          "valueCoding": {
+            "code": "kg",
+            "display": "kg"
+          }
+        }
+      ],
+      "linkId": "100000-nodecimals",
+      "type": "decimal",
+      "text": "Enter your weight in kg (no decimals)"
     },
     {
       "extension": [

--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -129,22 +129,10 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
     }
 
     // Build a number format based on item and SDC properties.
-    final maxIntegerDigits = (_maxValue != double.maxFinite)
-        ? '############'.substring(0, _maxValue.toInt().toString().length)
-        : '############';
-    final maxFractionDigits =
-        (_maxDecimal != 0) ? '.0#####'.substring(0, _maxDecimal + 1) : '';
-
-    _numberPattern = '$maxIntegerDigits$maxFractionDigits';
-
-    _logger.debug(
-      'input format for ${questionnaireItemModel.linkId}: "$_numberPattern"',
+    _numberFormat = NumberFormat.decimalPatternDigits(
+      locale: locale.toLanguageTag(), // TODO: toString or toLanguageTag?
+      decimalDigits: _maxDecimal,
     );
-
-    _numberFormat = NumberFormat(
-      _numberPattern,
-      locale.toLanguageTag(),
-    ); // TODO: toString or toLanguageTag?
 
     _units = <String, Coding>{};
     final unitsUri = qi.extension_

--- a/lib/questionnaires/view/item/answer/src/numerical_input_formatter.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_input_formatter.dart
@@ -36,6 +36,11 @@ class NumericalTextInputFormatter extends TextInputFormatter {
 
     try {
       final parsed = numberFormat.parse(newValue.text);
+
+      // Parsed numbers always contain decimals (12 -> 12.0, 12.3 -> 12.3)
+      final decimals = parsed.toString().split('.')[1];
+      if (decimals != '0' && decimals.length > numberFormat.maximumFractionDigits) return oldValue;
+
       _logger.trace('parsed: ${newValue.text} -> $parsed');
 
       return newValue;

--- a/lib/questionnaires/view/item/answer/src/numerical_input_formatter.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_input_formatter.dart
@@ -37,9 +37,13 @@ class NumericalTextInputFormatter extends TextInputFormatter {
     try {
       final parsed = numberFormat.parse(newValue.text);
 
-      // Parsed numbers always contain decimals (12 -> 12.0, 12.3 -> 12.3)
-      final decimals = parsed.toString().split('.')[1];
-      if (decimals != '0' && decimals.length > numberFormat.maximumFractionDigits) return oldValue;
+      // The assumption here is that if parsing was successful, the text should be a valid
+      // numberical string, and can thus be split in integer and decimal parts.
+      final numberParts = newValue.text.split(numberFormat.symbols.DECIMAL_SEP);
+      if (numberParts.length > 1) {
+        final decimals = numberParts[1];
+        if (decimals.length > numberFormat.maximumFractionDigits) return oldValue;
+      }
 
       _logger.trace('parsed: ${newValue.text} -> $parsed');
 


### PR DESCRIPTION
This PR contains the following changes:

* Fixes numerical inputs not respecting the number of decimal digits specified in the `maxDecimalPlaces` extension.
* Simplifies how the number formatter is built by using `NumberFormat.decimalPatternDigits`.
* Removes some logic for constraining the amount of digits in the integer part of numbers:
  * If needed, we can implemented.
  * From what I could see, this also didn't work as expected, in the same way as constraining decimal digits didn't work, so you could type long integer numbers anyway.
  * The restriction was based only on `maxValue`, so it may or may not have caused issues with negative numbers.
* If `maxDecimalPlaces` is not specified, by default the max number of decimals digits is set to 3.
  * Apparently this was the original intended behavior as defined in https://github.com/sujrd/faiadashu/blob/develop/lib/questionnaires/model/src/questionnaire_model_defaults.dart#L9
  * This can be changed via the `QuestionnaireModelDefaults.maxDecimals` setting.