### PR TITLE
minQuantity/maxQuantity support

### DIFF
--- a/example/assets/instruments/sdc_demo.json
+++ b/example/assets/instruments/sdc_demo.json
@@ -395,6 +395,61 @@
       "type": "quantity"
     },
     {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption",
+          "valueCoding": {
+            "code": "kg",
+            "system": "http://unitsofmeasure.org",
+            "display": "kg"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption",
+          "valueCoding": {
+            "code" : "[lb_av]",
+            "system": "http://unitsofmeasure.org",
+            "display" : "lb"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-minQuantity",
+          "valueQuantity": {
+            "value": 10,
+            "system": "http://unitsofmeasure.org",
+            "code": "kg"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-maxQuantity",
+          "valueQuantity": {
+            "value": 100,
+            "system": "http://unitsofmeasure.org",
+            "code": "kg"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-minQuantity",
+          "valueQuantity": {
+            "value": 22,
+            "system": "http://unitsofmeasure.org",
+            "code": "[lb_av]"
+          }
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-maxQuantity",
+          "valueQuantity": {
+            "value": 220,
+            "system": "http://unitsofmeasure.org",
+            "code": "[lb_av]"
+          }
+        }
+      ],
+      "linkId": "2.8.b-weight-quantity-ranges",
+      "text": "Body Weight (with unit selector and min/max value validations per unit)",
+      "type": "quantity"
+    },
+    {
       "linkId": "123523.35235",
       "type": "string",
       "text": "Enter your First Name",

--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -79,13 +79,18 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
   }
 
   NumericalAnswerModel(super.responseModel) {
+    _initializeRanges();
+    _initializeFormatting();
+    _initializeUnits();
+  }
+
+  void _initializeRanges() {
     _isSliding =
         questionnaireItemModel.questionnaireItem.isItemControl('slider');
 
     final minValueExtension = qi.extension_
         ?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/minValue');
-    final maxValueExtension = questionnaireItemModel
-        .questionnaireItem.extension_
+    final maxValueExtension = qi.extension_
         ?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/maxValue');
     _minValue = minValueExtension?.valueDecimal?.value ??
         minValueExtension?.valueInteger?.value?.toDouble() ??
@@ -107,8 +112,9 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
       _upperSliderLabel = questionnaireItemModel.upperTextItem?.text;
       _lowerSliderLabel = questionnaireItemModel.lowerTextItem?.text;
     }
+  }
 
-    // TODO: Evaluate max length
+  void _initializeFormatting() {
     switch (qi.type) {
       case QuestionnaireItemType.integer:
         _maxDecimal = 0;
@@ -133,12 +139,13 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
       locale: locale.toLanguageTag(), // TODO: toString or toLanguageTag?
       decimalDigits: _maxDecimal,
     );
+  }
 
+  void _initializeUnits() {
     _units = <String, Coding>{};
+
     final unitsUri = qi.extension_
-        ?.extensionOrNull(
-          'http://hl7.org/fhir/StructureDefinition/questionnaire-unitValueSet',
-        )
+        ?.extensionOrNull('http://hl7.org/fhir/StructureDefinition/questionnaire-unitValueSet')
         ?.valueCanonical
         .toString();
     if (unitsUri != null) {
@@ -152,8 +159,7 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
     }
 
     qi.extension_
-        ?.whereExtensionIs(
-            'http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption')
+        ?.whereExtensionIs('http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption')
         ?.forEach((extension) {
       final coding = extension.valueCoding;
       if (coding == null) return;
@@ -165,8 +171,9 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
         ?.extensionOrNull(
             'http://hl7.org/fhir/StructureDefinition/questionnaire-unit')
         ?.valueCoding;
-    if (questionnaireUnit != null && questionnaireUnit.display != null)
+    if (questionnaireUnit != null && questionnaireUnit.display != null) {
       _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
+    }
   }
 
   @override


### PR DESCRIPTION
This PR adds the following changes:

* Splits the constructor of `NumericalAnswerModel`
  * My IDE was complaining about the constructor being too long, and I agree.
* Adds basic support for [minQuantity](https://build.fhir.org/ig/HL7/sdc//behavior.html#minQuantity) and [maxQuantity](https://build.fhir.org/ig/HL7/sdc//behavior.html#maxQuantity) extensions. There are some behaviors different to the FHIR SDC specs though:
  * The spec says this should only be used with UCUM units, which we are not validating.
  * The spec also says answer.valueQuantity should be converted to the same units as min/maxQuantity for comparison, which we don't do either.
    * UCUM has a web service for performing unit conversions, but perhaps this is a bit overkill, and we cannot guarantee the app will always be used online anyway.
  * Instead, if multiple units are defined for a quantity field, and min/max validations are needed, then multiple min/maxQuantity extensions need to be defined, one for each unit.
* Other things to keep in mind:
  * The library allows setting itemControl=slider for decimals and quantities, which depend on the min/maxValues to set the slider range. I'm not sure yet about how to handle this one for quantities with min/maxQuantity extensions.