### PR TITLE
Fix numeric field null check errors

### DIFF
--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -37,7 +37,7 @@ class _NumericalAnswerState extends QuestionnaireAnswerFillerState<Quantity,
     );
 
     const averageDivisor = 2.0;
-    _sliderValueDuringChange.value = (answerModel.value != null)
+    _sliderValueDuringChange.value = (answerModel.value?.value != null)
         ? answerModel.value!.value!.value!
         : (answerModel.maxValue - answerModel.minValue) / averageDivisor;
 


### PR DESCRIPTION
Fixes #56.

The error is introduced because of using the non-nullable operator (!) when the value of `answerModel.value.value` can be actually null.