### PR TITLE
Provide inherited access to stepper controller

### DIFF
--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -69,52 +69,55 @@ class _CustomQuestionnaireStepperPageState
           children: [
             Expanded(
               child: QuestionnaireStepper(
-                  scaffoldBuilder: DefaultQuestionnairePageScaffoldBuilder(
-                      persistentFooterButtons: [
-                        PopupMenuButton<Locale>(
-                          icon: const Icon(Icons.language),
-                          onSelected: (Locale locale) {
-                            LocaleInheritedWidget.of(context)
-                                .updateLocale(locale);
-                          },
-                          itemBuilder: (BuildContext context) =>
-                              <PopupMenuEntry<Locale>>[
-                            const PopupMenuItem<Locale>(
-                              value: Locale('en'),
-                              child: Text('English'),
-                            ),
-                            const PopupMenuItem<Locale>(
-                              value: Locale('ar'),
-                              child: Text('عَرَبِيّ'),
-                            ),
-                            const PopupMenuItem<Locale>(
-                              value: Locale('de'),
-                              child: Text('Deutsch'),
-                            ),
-                            const PopupMenuItem<Locale>(
-                              value: Locale('es'),
-                              child: Text('Español'),
-                            ),
-                            const PopupMenuItem<Locale>(
-                              value: Locale('ja'),
-                              child: Text('日本語'),
-                            ),
-                          ],
+                scaffoldBuilder: DefaultQuestionnairePageScaffoldBuilder(
+                  persistentFooterButtons: [
+                    PopupMenuButton<Locale>(
+                      icon: const Icon(Icons.language),
+                      onSelected: (Locale locale) {
+                        LocaleInheritedWidget.of(context).updateLocale(locale);
+                      },
+                      itemBuilder: (BuildContext context) =>
+                          <PopupMenuEntry<Locale>>[
+                        const PopupMenuItem<Locale>(
+                          value: Locale('en'),
+                          child: Text('English'),
                         ),
-                      ]),
-                  fhirResourceProvider: widget.fhirResourceProvider,
-                  launchContext: widget.launchContext,
+                        const PopupMenuItem<Locale>(
+                          value: Locale('ar'),
+                          child: Text('عَرَبِيّ'),
+                        ),
+                        const PopupMenuItem<Locale>(
+                          value: Locale('de'),
+                          child: Text('Deutsch'),
+                        ),
+                        const PopupMenuItem<Locale>(
+                          value: Locale('es'),
+                          child: Text('Español'),
+                        ),
+                        const PopupMenuItem<Locale>(
+                          value: Locale('ja'),
+                          child: Text('日本語'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                fhirResourceProvider: widget.fhirResourceProvider,
+                launchContext: widget.launchContext,
+                data: QuestionnaireStepperPageViewData(
                   controller: _controller,
-                  onQuestionnaireResponseChanged: (questionnaireResponseModel) {
-                    _questionnaireResponseModel = questionnaireResponseModel;
-                  },
                   onPageChanged: _onPageChanged,
                   onBeforePageChanged: (currentItemModel, nextItemModel) async {
                     return BeforePageChangedData(canProceed: true);
                   },
                   onVisibleItemUpdated: (item) {
                     _fillerItemFiller = item;
-                  }),
+                  },
+                ),
+                onQuestionnaireResponseChanged: (questionnaireResponseModel) {
+                  _questionnaireResponseModel = questionnaireResponseModel;
+                },
+              ),
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -10,43 +10,51 @@ class QuestionnaireStepper extends StatefulWidget {
   final LaunchContext launchContext;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
   final QuestionnaireModelDefaults questionnaireModelDefaults;
-  final QuestionnaireStepperPageViewController? controller;
+  final QuestionnaireStepperPageViewData? data;
 
   final void Function(QuestionnaireResponseModel?)?
       onQuestionnaireResponseChanged;
+
+  @Deprecated('Use `data` instead')
+  final QuestionnaireStepperPageViewController? controller;
+  @Deprecated('Use `data` instead')
   final void Function(int)? onPageChanged;
+  @Deprecated('Use `data` instead')
   final Future<BeforePageChangedData> Function(
     FillerItemModel,
     FillerItemModel?,
   )? onBeforePageChanged;
+  @Deprecated('Use `data` instead')
   final void Function(FillerItemModel?)? onVisibleItemUpdated;
 
   const QuestionnaireStepper({
+    super.key,
     required this.scaffoldBuilder,
     required this.fhirResourceProvider,
     required this.launchContext,
+    this.data,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
     this.onQuestionnaireResponseChanged,
-    this.onPageChanged,
-    this.onBeforePageChanged,
-    this.onVisibleItemUpdated,
-    this.controller,
-    Key? key,
-  }) : super(key: key);
+    @Deprecated('Use `data` instead') this.onPageChanged,
+    @Deprecated('Use `data` instead') this.onBeforePageChanged,
+    @Deprecated('Use `data` instead') this.onVisibleItemUpdated,
+    @Deprecated('Use `data` instead') this.controller,
+  });
 
   @override
   State<StatefulWidget> createState() => QuestionnaireStepperState();
 }
 
 class QuestionnaireStepperState extends State<QuestionnaireStepper> {
+  late QuestionnaireStepperPageViewController _controller;
   QuestionnaireResponseModel? _questionnaireResponseModel;
-  QuestionnaireStepperPageViewController? _controller;
   bool _isLoaded = false;
 
   @override
   void initState() {
     super.initState();
-    _controller = widget.controller ?? QuestionnaireStepperPageViewController();
+    _controller =
+        widget.data?.controller ?? QuestionnaireStepperPageViewController();
   }
 
   /// Notifies listeners when there are changes in the questionnaire response.
@@ -68,20 +76,19 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
             children: [
               Expanded(
                 child: QuestionnaireStepperPageView(
-                  controller: _controller,
-                  physics: widget.controller != null ? const NeverScrollableScrollPhysics() : null,
-                  onPageChanged: widget.onPageChanged,
-                  onBeforePageChanged: widget.onBeforePageChanged,
-                  onVisibleItemUpdated: widget.onVisibleItemUpdated,
+                  data: widget.data ??
+                      QuestionnaireStepperPageViewData(
+                        controller: _controller,
+                      ),
                 ),
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  if (widget.controller == null)
+                  if (widget.data?.controller == null)
                     IconButton(
                       icon: const Icon(Icons.arrow_back),
-                      onPressed: () => widget.controller?.previousPage(),
+                      onPressed: () => _controller.previousPage(),
                     ),
                   Expanded(
                     child: Column(
@@ -115,10 +122,10 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                       ],
                     ),
                   ),
-                  if (widget.controller == null)
+                  if (widget.data?.controller == null)
                     IconButton(
                       icon: const Icon(Icons.arrow_forward),
-                      onPressed: () => _controller?.nextPage(),
+                      onPressed: () => _controller.nextPage(),
                     ),
                 ],
               ),

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -69,6 +69,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
               Expanded(
                 child: QuestionnaireStepperPageView(
                   controller: _controller,
+                  physics: widget.controller != null ? const NeverScrollableScrollPhysics() : null,
                   onPageChanged: widget.onPageChanged,
                   onBeforePageChanged: widget.onBeforePageChanged,
                   onVisibleItemUpdated: widget.onVisibleItemUpdated,
@@ -117,7 +118,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                   if (widget.controller == null)
                     IconButton(
                       icon: const Icon(Icons.arrow_forward),
-                      onPressed: () => widget.controller?.nextPage(),
+                      onPressed: () => _controller?.nextPage(),
                     ),
                 ],
               ),

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -15,18 +15,6 @@ class QuestionnaireStepper extends StatefulWidget {
   final void Function(QuestionnaireResponseModel?)?
       onQuestionnaireResponseChanged;
 
-  @Deprecated('Use `data` instead')
-  final QuestionnaireStepperPageViewController? controller;
-  @Deprecated('Use `data` instead')
-  final void Function(int)? onPageChanged;
-  @Deprecated('Use `data` instead')
-  final Future<BeforePageChangedData> Function(
-    FillerItemModel,
-    FillerItemModel?,
-  )? onBeforePageChanged;
-  @Deprecated('Use `data` instead')
-  final void Function(FillerItemModel?)? onVisibleItemUpdated;
-
   const QuestionnaireStepper({
     super.key,
     required this.scaffoldBuilder,
@@ -35,10 +23,6 @@ class QuestionnaireStepper extends StatefulWidget {
     this.data,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
     this.onQuestionnaireResponseChanged,
-    @Deprecated('Use `data` instead') this.onPageChanged,
-    @Deprecated('Use `data` instead') this.onBeforePageChanged,
-    @Deprecated('Use `data` instead') this.onVisibleItemUpdated,
-    @Deprecated('Use `data` instead') this.controller,
   });
 
   @override

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -17,6 +17,14 @@ class QuestionnaireStepperPageView extends StatefulWidget {
     required this.data,
   });
 
+  static QuestionnaireStepperPageViewData of(BuildContext context) {
+    final result = context.dependOnInheritedWidgetOfExactType<
+        _QuestionnaireStepperPageViewInheritedWidget>();
+    assert(result != null,
+        'No QuestionnaireStepperInheritedWidget found in context');
+    return result!.data;
+  }
+
   @override
   _QuestionnaireStepperPageViewState createState() =>
       _QuestionnaireStepperPageViewState();
@@ -87,7 +95,7 @@ class _QuestionnaireStepperPageViewState
 
   @override
   Widget build(BuildContext context) {
-    return QuestionnaireStepperPageViewInheritedWidget(
+    return _QuestionnaireStepperPageViewInheritedWidget(
       data: widget.data,
       child: PageView.builder(
         /// [PageView.scrollDirection] defaults to [Axis.horizontal].
@@ -211,26 +219,18 @@ class BeforePageChangedData {
 }
 
 // ignore: prefer-single-widget-per-file
-class QuestionnaireStepperPageViewInheritedWidget extends InheritedWidget {
+class _QuestionnaireStepperPageViewInheritedWidget extends InheritedWidget {
   final QuestionnaireStepperPageViewData data;
 
-  const QuestionnaireStepperPageViewInheritedWidget({
+  const _QuestionnaireStepperPageViewInheritedWidget({
     super.key,
     required super.child,
     required this.data,
   });
 
-  static QuestionnaireStepperPageViewData of(BuildContext context) {
-    final result = context.dependOnInheritedWidgetOfExactType<
-        QuestionnaireStepperPageViewInheritedWidget>();
-    assert(result != null,
-        'No QuestionnaireStepperInheritedWidget found in context');
-    return result!.data;
-  }
-
   @override
   bool updateShouldNotify(
-    QuestionnaireStepperPageViewInheritedWidget oldWidget,
+    _QuestionnaireStepperPageViewInheritedWidget oldWidget,
   ) {
     return data != oldWidget.data;
   }

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -238,7 +238,7 @@ class QuestionnaireStepperPageViewInheritedWidget extends InheritedWidget {
 
 // ignore: prefer-single-widget-per-file
 class QuestionnaireStepperPageViewData {
-  final QuestionnaireStepperPageViewController controller;
+  late final QuestionnaireStepperPageViewController controller;
   final ScrollPhysics? physics;
   final ValueChanged<int>? onPageChanged;
   final Future<BeforePageChangedData> Function(
@@ -247,11 +247,13 @@ class QuestionnaireStepperPageViewData {
   )? onBeforePageChanged;
   final void Function(FillerItemModel?)? onVisibleItemUpdated;
 
-  const QuestionnaireStepperPageViewData({
-    required this.controller,
+  QuestionnaireStepperPageViewData({
+    QuestionnaireStepperPageViewController? controller,
     this.physics,
     this.onPageChanged,
     this.onBeforePageChanged,
     this.onVisibleItemUpdated,
-  });
+  }) {
+    this.controller = controller ?? QuestionnaireStepperPageViewController();
+  }
 }


### PR DESCRIPTION
This PR makes the following changes:
* Adds a `QuestionnaireStepperPageViewData` inherited widget
  * Provides access to the stepper `controller`
* Adds a `QuestionnaireStepperPageView.of` method to get back a `QuestionnaireStepperPageViewData` if invoked form within the rendering tree.
* Adds methods to transition to a specific stepper page.
* Fixes a bug in which the stepper `next` button would not go to the next page, unless a controller was provided.