### PR TITLE
Add support for initialSelected in choice and open-choice questions

### DIFF
--- a/lib/questionnaires/model/item/src/question_item_model.dart
+++ b/lib/questionnaires/model/item/src/question_item_model.dart
@@ -316,9 +316,17 @@ class QuestionItemModel extends ResponseItemModel {
       firstAnswerModel.populateFromExpression(initialEvaluationResult);
     } else {
       // initial.value[x]
-      final initialValues = questionnaireItem.initial;
+      final initialValues = questionnaireItem.initial ?? [];
 
-      if (initialValues != null) {
+      if ({QuestionnaireItemType.choice,QuestionnaireItemType.open_choice}.contains(questionnaireItem.type)) {
+        // Add answerOptions marked as initialSelected to array of initialValues
+        final initialSelected = questionnaireItem.answerOption
+            ?.where((option) => option.initialSelected?.value == true && option.valueCoding != null)
+            .map((option) => QuestionnaireInitial(valueCoding: option.valueCoding));
+        initialValues.addAll(initialSelected ?? []);
+      }
+
+      if (initialValues.isNotEmpty) {
         final initialValue = initialValues.first;
 
         switch (questionnaireItem.type) {


### PR DESCRIPTION
fixes #45 

Adds support to set initial values for choice and open-choice questions via [answerOption.initialSelected](http://hl7.org/fhir/R5/questionnaire-definitions.html#Questionnaire.item.answerOption.initialSelected).

This could be verified easily with the SDC Demo form example.
This one already has a `Gender` question in which `initialSelected` is set to true for the `Female` option, but thus far was being ignored.
The form also has multiple open-choice questions which can be used to test this.