### PR TITLE
Fix cannot add to an unmodifiable list error on certain conditions

### DIFF
--- a/lib/questionnaires/model/item/src/question_item_model.dart
+++ b/lib/questionnaires/model/item/src/question_item_model.dart
@@ -316,7 +316,9 @@ class QuestionItemModel extends ResponseItemModel {
       firstAnswerModel.populateFromExpression(initialEvaluationResult);
     } else {
       // initial.value[x]
-      final initialValues = questionnaireItem.initial ?? [];
+      // toList is to handle "Unhandled Exception: Unsupported operation: Cannot add to an unmodifiable list"
+      // errors
+      final initialValues = (questionnaireItem.initial ?? []).toList();
 
       if ({QuestionnaireItemType.choice,QuestionnaireItemType.open_choice}.contains(questionnaireItem.type)) {
         // Add answerOptions marked as initialSelected to array of initialValues


### PR DESCRIPTION
Fixes a `Unhandled Exception: Unsupported operation: Cannot add to an unmodifiable list` error thrown if you scroll down enough on the list of Questionnaires in the example app after the changes for #45.