### PR TITLE
Address linter warnings

### DIFF
--- a/example/lib/about_page.dart
+++ b/example/lib/about_page.dart
@@ -4,7 +4,7 @@ import 'package:simple_html_css/simple_html_css.dart';
 import 'exhibit_page.dart';
 
 class AboutPage extends ExhibitPage {
-  const AboutPage({Key? key}) : super(key: key);
+  const AboutPage({super.key});
 
   @override
   Widget buildExhibit(BuildContext context) {
@@ -21,7 +21,7 @@ class AboutPage extends ExhibitPage {
     <p><b>I love the sound of it.</b><br>
     <div style="font-size: 10px; color:#888888">私はその音が大好きです。</div></p> 
     ''',
-        defaultTextStyle: Theme.of(context).textTheme.bodyText1,
+        defaultTextStyle: Theme.of(context).textTheme.bodyLarge,
       ),
     );
   }

--- a/example/lib/cherry_blossom_theme.dart
+++ b/example/lib/cherry_blossom_theme.dart
@@ -71,13 +71,13 @@ class CherryBlossomScaffoldBuilder extends QuestionnairePageScaffoldBuilder {
           focusedErrorBorder: OutlineInputBorder(
             borderSide: BorderSide(
               width: 2.0,
-              color: ThemeData.light().errorColor,
+              color: ThemeData.light().colorScheme.error,
             ),
           ),
           errorBorder: OutlineInputBorder(
             borderSide: BorderSide(
               width: 2.0,
-              color: ThemeData.light().errorColor.withOpacity(0.12),
+              color: ThemeData.light().colorScheme.error.withOpacity(0.12),
             ),
           ),
           focusedBorder: const OutlineInputBorder(
@@ -101,7 +101,7 @@ class CherryBlossomScaffoldBuilder extends QuestionnairePageScaffoldBuilder {
                 padding: const EdgeInsets.symmetric(vertical: 8),
                 child: Text(
                   '🦄🌸🦄🌸🦄🌸🦄',
-                  style: Theme.of(context).textTheme.headline4,
+                  style: Theme.of(context).textTheme.headlineMedium,
                 ),
               ),
               Expanded(

--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -57,13 +57,14 @@ class _CustomQuestionnaireStepperPageState
   }
 
   void _onPageChanged(int index) {
+    // ignore: avoid_print
     print('Page index is changed: $index');
   }
 
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Container(
+      child: ColoredBox(
         color: Colors.white,
         child: Column(
           children: [

--- a/example/lib/disclaimer_page.dart
+++ b/example/lib/disclaimer_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'exhibit_page.dart';
 
 class DisclaimerPage extends ExhibitPage {
-  const DisclaimerPage({Key? key}) : super(key: key);
+  const DisclaimerPage({super.key});
 
   @override
   Widget buildExhibit(BuildContext context) {

--- a/example/lib/exhibit_page.dart
+++ b/example/lib/exhibit_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 abstract class ExhibitPage extends StatelessWidget {
-  const ExhibitPage({Key? key}) : super(key: key);
+  const ExhibitPage({super.key});
 
   String get title;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   MyAppState createState() => MyAppState();
@@ -95,11 +95,11 @@ class LocaleInheritedWidget extends InheritedWidget {
   final Locale currentLocale;
 
   const LocaleInheritedWidget({
-    Key? key,
+    super.key,
     required this.updateLocale,
     required this.currentLocale,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   @override
   bool updateShouldNotify(LocaleInheritedWidget old) {
@@ -112,7 +112,7 @@ class LocaleInheritedWidget extends InheritedWidget {
 }
 
 class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   // ignore: library_private_types_in_public_api
@@ -175,7 +175,7 @@ class _HomePageState extends State<HomePage> {
   /// Schedules repaint after login / logout.
   void _onLoginChanged() {
     _logger.debug(
-        '_onLoginChanged: ${questionnaireResponseStorage.smartClient.isLoggedIn()}');
+        '_onLoginChanged: ${questionnaireResponseStorage.smartClient.isLoggedIn()}',);
     setState(() {
       // Rebuild
     });
@@ -212,7 +212,7 @@ class _HomePageState extends State<HomePage> {
               title,
               style: Theme.of(context)
                   .textTheme
-                  .headline6
+                  .titleLarge
                   ?.copyWith(fontWeight: FontWeight.bold),
             ),
             Text(subtitle)
@@ -248,7 +248,7 @@ class _HomePageState extends State<HomePage> {
         ),
         actions: [
           SmartLoginButton(questionnaireResponseStorage.smartClient,
-              onLoginChanged: _onLoginChanged)
+              onLoginChanged: _onLoginChanged,)
         ],
       ),
       body: SafeArea(

--- a/example/lib/observation_page.dart
+++ b/example/lib/observation_page.dart
@@ -4,7 +4,7 @@ import 'package:fhir/r4.dart';
 import 'package:flutter/material.dart';
 
 class ObservationPage extends ExhibitPage {
-  ObservationPage({Key? key}) : super(key: key);
+  ObservationPage({super.key});
 
   final bpObservation = Observation(
     effectiveDateTime: FhirDateTime(DateTime.now()),
@@ -103,18 +103,18 @@ class ObservationPage extends ExhibitPage {
       children: [
         ObservationView(
           bpObservation,
-          valueStyle: Theme.of(context).textTheme.headline4,
-          codeStyle: Theme.of(context).textTheme.subtitle2,
-          dateTimeStyle: Theme.of(context).textTheme.caption,
+          valueStyle: Theme.of(context).textTheme.headlineMedium,
+          codeStyle: Theme.of(context).textTheme.titleSmall,
+          dateTimeStyle: Theme.of(context).textTheme.bodySmall,
         ),
         const SizedBox(
           height: 16,
         ),
         ObservationView(
           bpObservationWHR,
-          valueStyle: Theme.of(context).textTheme.headline4,
-          codeStyle: Theme.of(context).textTheme.subtitle2,
-          dateTimeStyle: Theme.of(context).textTheme.caption,
+          valueStyle: Theme.of(context).textTheme.headlineMedium,
+          codeStyle: Theme.of(context).textTheme.titleSmall,
+          dateTimeStyle: Theme.of(context).textTheme.bodySmall,
         ),
         const SizedBox(
           height: 16,
@@ -127,9 +127,9 @@ class ObservationPage extends ExhibitPage {
           ),
           child: ObservationView(
             bpObservationWHR,
-            valueStyle: Theme.of(context).textTheme.headline4,
-            codeStyle: Theme.of(context).textTheme.subtitle2,
-            dateTimeStyle: Theme.of(context).textTheme.caption,
+            valueStyle: Theme.of(context).textTheme.headlineMedium,
+            codeStyle: Theme.of(context).textTheme.titleSmall,
+            dateTimeStyle: Theme.of(context).textTheme.bodySmall,
           ),
         ),
       ],

--- a/example/lib/primitive_page.dart
+++ b/example/lib/primitive_page.dart
@@ -5,18 +5,18 @@ import 'package:flutter/material.dart';
 import 'exhibit_page.dart';
 
 class PrimitivePage extends ExhibitPage {
-  const PrimitivePage({Key? key}) : super(key: key);
+  const PrimitivePage({super.key});
 
   @override
   Widget buildExhibit(BuildContext context) {
     return Column(
       children: [
-        Text('Default locale', style: Theme.of(context).textTheme.headline6),
+        Text('Default locale', style: Theme.of(context).textTheme.titleLarge),
         FhirDateTimeText(FhirDateTime('2002-02-05')),
         FhirDateTimeText(FhirDateTime('2010-02-05 14:02')),
         FhirDateTimeText(FhirDateTime('2010-02')),
         const Spacer(),
-        Text('Germany', style: Theme.of(context).textTheme.headline6),
+        Text('Germany', style: Theme.of(context).textTheme.titleLarge),
         Localizations.override(
           context: context,
           locale: const Locale.fromSubtags(
@@ -28,7 +28,7 @@ class PrimitivePage extends ExhibitPage {
           ),
         ),
         const Spacer(),
-        Text('Japan', style: Theme.of(context).textTheme.headline6),
+        Text('Japan', style: Theme.of(context).textTheme.titleLarge),
         Localizations.override(
           context: context,
           locale: const Locale.fromSubtags(
@@ -50,7 +50,7 @@ class PrimitivePage extends ExhibitPage {
           ),
         ),
         const Spacer(),
-        Text('Bahrain', style: Theme.of(context).textTheme.headline6),
+        Text('Bahrain', style: Theme.of(context).textTheme.titleLarge),
         Localizations.override(
           context: context,
           locale: const Locale.fromSubtags(

--- a/example/lib/questionnaire_launch_tile.dart
+++ b/example/lib/questionnaire_launch_tile.dart
@@ -16,9 +16,9 @@ class QuestionnaireLaunchTile extends StatefulWidget {
   final FhirResourceProvider fhirResourceProvider;
   final LaunchContext launchContext;
   final void Function(String questionnairePath,
-      QuestionnaireResponse? questionnaireResponse) saveResponseFunction;
+      QuestionnaireResponse? questionnaireResponse,) saveResponseFunction;
   final void Function(BuildContext context, String questionnairePath,
-      QuestionnaireResponse? questionnaireResponse)? uploadResponseFunction;
+      QuestionnaireResponse? questionnaireResponse,)? uploadResponseFunction;
   final QuestionnaireResponse? Function(String questionnairePath)
       restoreResponseFunction;
 
@@ -35,8 +35,8 @@ class QuestionnaireLaunchTile extends StatefulWidget {
     this.uploadResponseFunction,
     required this.restoreResponseFunction,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   // ignore: library_private_types_in_public_api
@@ -93,13 +93,13 @@ class _QuestionnaireLaunchTileState extends State<QuestionnaireLaunchTile> {
           var countString = '';
           if (snapshot.hasData) {
             // FIXME: Sometimes these stats are not being shown. Handle snapshot error.
-            final _questionnaireResponseModel = snapshot.data!;
-            final _numberCompleted =
-                _questionnaireResponseModel.count((rim) => rim.isAnswered);
-            final _totalNumber =
-                _questionnaireResponseModel.count((rim) => rim.isAnswerable);
-            countString = 'Completed: $_numberCompleted / $_totalNumber '
-                '(${_percentPattern.format(_numberCompleted / _totalNumber)})';
+            final questionnaireResponseModel = snapshot.data!;
+            final numberCompleted =
+                questionnaireResponseModel.count((rim) => rim.isAnswered);
+            final totalNumber =
+                questionnaireResponseModel.count((rim) => rim.isAnswerable);
+            countString = 'Completed: $numberCompleted / $totalNumber '
+                '(${_percentPattern.format(numberCompleted / totalNumber)})';
           }
 
           return (widget.subtitle != null)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+6"
   crypto:
     dependency: transitive
     description:
@@ -127,6 +135,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
+  file_selector:
+    dependency: transitive
+    description:
+      name: file_selector
+      sha256: "1d2fde93dddf634a9c3c0faa748169d7ac0d83757135555707e52f02c017ad4f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_android:
+    dependency: transitive
+    description:
+      name: file_selector_android
+      sha256: b7556052dbcc25ef88f6eba45ab98aa5600382af8dfdabc9d644a93d97b7be7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0+4"
+  file_selector_ios:
+    dependency: transitive
+    description:
+      name: file_selector_ios
+      sha256: b3fbdda64aa2e335df6e111f6b0f1bb968402ed81d2dd1fa4274267999aa32c2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1+6"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2+1"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+3"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "0aa47a725c346825a2bd396343ce63ac00bda6eff2fbc43eabe99737dede8262"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  file_selector_web:
+    dependency: transitive
+    description:
+      name: file_selector_web
+      sha256: dc6622c4d66cb1bee623ddcc029036603c6cc45c85e4a775bb06008d61c809c1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.2+1"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+1"
+  filesize:
+    dependency: transitive
+    description:
+      name: filesize
+      sha256: f53df1f27ff60e466eefcd9df239e02d4722d5e2debee92a87dfd99ac66de2af
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -258,10 +338,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lint
-      sha256: "5715d702a2c3b493e09ed9e223625f0fc1f75e04167e338133a4cef28b868c1f"
+      sha256: f4bd4dbaa39f4ae8836f2d1275f2f32bc68b3a8cce0a0735dd1f7a601f06682a
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "2.1.2"
   logging:
     dependency: "direct main"
     description:
@@ -302,6 +382,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   oauth2:
     dependency: transitive
     description:
@@ -628,5 +716,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=3.0.0"
+  dart: ">=3.0.0 <4.0.0"
+  flutter: ">=3.7.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   simple_html_css: ^3.0.1+1
 
 dev_dependencies:
-  lint: ^1.8.2
+  lint: ^2.0.0
 
 
 flutter:

--- a/faiabench/lib/about_page.dart
+++ b/faiabench/lib/about_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:simple_html_css/simple_html_css.dart';
 
 class AboutPage extends ExhibitPage {
-  const AboutPage({Key? key}) : super(key: key);
+  const AboutPage({super.key});
 
   @override
   Widget buildExhibit(BuildContext context) {
@@ -20,7 +20,7 @@ class AboutPage extends ExhibitPage {
     <p><b>I love the sound of it.</b><br>
     <div style="font-size: 10px; color:#888888">私はその音が大好きです。</div></p> 
     ''',
-        defaultTextStyle: Theme.of(context).textTheme.bodyText1,
+        defaultTextStyle: Theme.of(context).textTheme.bodyLarge,
       ),
     );
   }

--- a/faiabench/lib/disclaimer_page.dart
+++ b/faiabench/lib/disclaimer_page.dart
@@ -2,7 +2,7 @@ import 'package:faiabench/exhibit_page.dart';
 import 'package:flutter/material.dart';
 
 class DisclaimerPage extends ExhibitPage {
-  const DisclaimerPage({Key? key}) : super(key: key);
+  const DisclaimerPage({super.key});
 
   @override
   Widget buildExhibit(BuildContext context) {

--- a/faiabench/lib/exhibit_page.dart
+++ b/faiabench/lib/exhibit_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 abstract class ExhibitPage extends StatelessWidget {
-  const ExhibitPage({Key? key}) : super(key: key);
+  const ExhibitPage({super.key});
 
   String get title;
 

--- a/faiabench/lib/fhir_resource_editor.dart
+++ b/faiabench/lib/fhir_resource_editor.dart
@@ -29,8 +29,8 @@ class FhirResourceEditor extends ConsumerStatefulWidget {
     this.showFhirPath = true,
     this.fhirPathOutputMinLines = 3,
     this.fhirPathOutputMaxLines = 3,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   // ignore: library_private_types_in_public_api
@@ -227,7 +227,7 @@ class _FhirResourceEditorState extends ConsumerState<FhirResourceEditor> {
                       if (fhirResource.hasError) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
-                            backgroundColor: Theme.of(context).errorColor,
+                            backgroundColor: Theme.of(context).colorScheme.error,
                             content: Text(fhirResource.errorMessage!),
                           ),
                         );

--- a/faiabench/lib/fhir_resource_editor.dart
+++ b/faiabench/lib/fhir_resource_editor.dart
@@ -126,9 +126,9 @@ class _FhirResourceEditorState extends ConsumerState<FhirResourceEditor> {
                   height: 120,
                   child: Stack(
                     children: [
-                      Container(
+                      const ColoredBox(
                         color: Colors.black54,
-                        child: const SizedBox.expand(),
+                        child: SizedBox.expand(),
                       ),
                       Column(
                         mainAxisSize: MainAxisSize.min,

--- a/faiabench/lib/json_tree.dart
+++ b/faiabench/lib/json_tree.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 class JsonTree extends StatefulWidget {
   final Resource resource;
 
-  const JsonTree(this.resource, {Key? key}) : super(key: key);
+  const JsonTree(this.resource, {super.key});
 
   @override
   // ignore: library_private_types_in_public_api

--- a/faiabench/lib/main.dart
+++ b/faiabench/lib/main.dart
@@ -108,7 +108,7 @@ final splitViewThemeData = MultiSplitViewThemeData(
 );
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -129,7 +129,7 @@ class MyApp extends StatelessWidget {
 }
 
 class HomePage extends ConsumerStatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   // ignore: library_private_types_in_public_api

--- a/faiabench/lib/questionnaire_scroller_panel.dart
+++ b/faiabench/lib/questionnaire_scroller_panel.dart
@@ -19,8 +19,8 @@ class QuestionnaireScrollerPanel extends ConsumerStatefulWidget {
     this.questionnaireResponse,
     this.launchContext,
     this.fillerOutputProvider, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   // ignore: library_private_types_in_public_api

--- a/faiabench/pubspec.yaml
+++ b/faiabench/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
 
 
 dev_dependencies:
-  lint: ^1.8.2
+  lint: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/faiadashu_online/lib/restful/src/server_uploader.dart
+++ b/faiadashu_online/lib/restful/src/server_uploader.dart
@@ -11,11 +11,11 @@ Future<QuestionnaireResponse> createOrUpdateQuestionnaireResponse(
   FhirClient client,
   QuestionnaireResponse questionnaireResponse,
 ) async {
-  final _logger = Logger.tag('server_uploader');
+  final logger = Logger.tag('server_uploader');
 
   final baseUri = ArgumentError.checkNotNull(client.fhirUri.value);
 
-  _logger.debug(
+  logger.debug(
     '${questionnaireResponse.resourceTypeString} to be uploaded:\n${questionnaireResponse.toJson()}',
   );
 
@@ -32,7 +32,7 @@ Future<QuestionnaireResponse> createOrUpdateQuestionnaireResponse(
 
   try {
     final serverResponse = await serverRequest.request();
-    _logger.debug('Response from server:\n${serverResponse.toJson()}');
+    logger.debug('Response from server:\n${serverResponse.toJson()}');
 
     if (serverResponse is QuestionnaireResponse) {
       return serverResponse;
@@ -42,7 +42,7 @@ Future<QuestionnaireResponse> createOrUpdateQuestionnaireResponse(
       throw Exception('Unexpected response from server:\n${serverResponse.toJson()}');
     }
   } catch (e) {
-    _logger.warn('Upload failed', error: e);
+    logger.warn('Upload failed', error: e);
     rethrow;
   }
 }

--- a/faiadashu_online/lib/restful/src/sync_indicator.dart
+++ b/faiadashu_online/lib/restful/src/sync_indicator.dart
@@ -38,10 +38,10 @@ class _SyncIndicatorState extends State<SyncIndicator>
     return AnimatedBuilder(
       key: _ingKey,
       animation: _animationController,
-      builder: (BuildContext context, Widget? _widget) {
+      builder: (BuildContext context, Widget? widget) {
         return Transform.rotate(
           angle: _animationController.value * 2 * pi,
-          child: _widget,
+          child: widget,
         );
       },
       child: Icon(Icons.sync, color: widget.color),

--- a/faiadashu_online/pubspec.yaml
+++ b/faiadashu_online/pubspec.yaml
@@ -36,7 +36,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  lint: ^1.8.2
+  lint: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/fhir_types/src/attachment_picker.dart
+++ b/lib/fhir_types/src/attachment_picker.dart
@@ -27,8 +27,8 @@ class FhirAttachmentPicker extends StatefulWidget {
     this.focusNode,
     this.allowedMimeTypes,
     this.enabled = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   // ignore: library_private_types_in_public_api

--- a/lib/fhir_types/src/base64_image.dart
+++ b/lib/fhir_types/src/base64_image.dart
@@ -17,8 +17,8 @@ class Base64Image extends StatefulWidget {
     this.semanticLabel,
     this.width,
     this.height,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() => _Base64ImageState();
@@ -38,7 +38,7 @@ class _Base64ImageState extends State<Base64Image> {
       height: widget.height,
       semanticLabel: widget.semanticLabel,
       key: (key != null && key is ValueKey)
-          ? ValueKey<String>('${key.value.toString()}-img')
+          ? ValueKey<String>('${key.value}-img')
           : null,
     );
   }

--- a/lib/fhir_types/src/codeable_concept_text.dart
+++ b/lib/fhir_types/src/codeable_concept_text.dart
@@ -9,8 +9,8 @@ class CodeableConceptText extends StatelessWidget {
   const CodeableConceptText(
     this.codeableConcept, {
     this.style,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -32,8 +32,8 @@ class FhirDateTimePicker extends StatefulWidget {
     this.onChanged,
     this.focusNode,
     this.enabled = true,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   // ignore: library_private_types_in_public_api

--- a/lib/fhir_types/src/date_time_picker.dart
+++ b/lib/fhir_types/src/date_time_picker.dart
@@ -97,6 +97,11 @@ class _FhirDateTimePickerState extends State<FhirDateTimePicker> {
       dateTime = date.toLocal();
     }
 
+    // To address use_build_context_synchronously as recommended, although this still triggers the linter
+    // https://dart.dev/tools/linter-rules/use_build_context_synchronously
+    // ignore: use_build_context_synchronously
+    if (!context.mounted) return;
+
     if (widget.pickerType == FhirDateTime || widget.pickerType == Time) {
       final time = await showTimePicker(
         initialTime:

--- a/lib/fhir_types/src/date_time_text.dart
+++ b/lib/fhir_types/src/date_time_text.dart
@@ -12,8 +12,8 @@ class FhirDateTimeText extends StatelessWidget {
     this.dateTime, {
     this.style,
     this.defaultText = '',
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/fhir_types/src/fhir_types_extensions.dart
+++ b/lib/fhir_types/src/fhir_types_extensions.dart
@@ -178,9 +178,9 @@ extension FDashCodeableConceptExtension on CodeableConcept {
 
   bool containsCoding(String? system, String code) {
     return coding?.firstWhereOrNull(
-          (_coding) =>
-              (_coding.code?.toString() == code) &&
-              (_coding.system?.toString() == system),
+          (coding) =>
+              (coding.code?.toString() == code) &&
+              (coding.system?.toString() == system),
         ) !=
         null;
   }

--- a/lib/fhir_types/src/resource_json_tree.dart
+++ b/lib/fhir_types/src/resource_json_tree.dart
@@ -11,8 +11,8 @@ class ResourceJsonTree extends StatefulWidget {
   const ResourceJsonTree(
     this.resourceRoot, {
     this.autoExpandLevel = defaultAutoExpandLevel,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final dynamic resourceRoot;
   final int autoExpandLevel;
@@ -83,8 +83,8 @@ abstract class _JsonNode<T> extends StatefulWidget {
     this.nodeValue,
     this.leftOffset,
     this.expandedDepth, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   final ResourceJsonTree root;
   final _JsonNode? parent;
@@ -114,22 +114,12 @@ abstract class _JsonNodeState<T extends _JsonNode> extends State<T> {
 
 class _JsonViewerMapNode extends _JsonNode<Map<String, dynamic>> {
   const _JsonViewerMapNode(
-    ResourceJsonTree root,
-    _JsonNode<dynamic>? parent,
-    String nodeName,
-    Map<String, dynamic> nodeValue,
-    double leftOffset,
-    int expandedDepth, {
-    Key? key,
-  }) : super(
-          root,
-          parent,
-          nodeName,
-          nodeValue,
-          leftOffset,
-          expandedDepth,
-          key: key,
-        );
+    super.root,
+    super.parent,
+    super.nodeName,
+    super.nodeValue,
+    super.leftOffset,
+    super.expandedDepth,);
 
   @override
   State<StatefulWidget> createState() => _MapNodeState();
@@ -159,7 +149,7 @@ class _MapNodeState extends _JsonNodeState<_JsonViewerMapNode> {
           ),
           Text(
             widget.nodeName,
-            style: Theme.of(context).textTheme.bodyText1,
+            style: Theme.of(context).textTheme.bodyLarge,
           ),
         ],
       ),
@@ -185,22 +175,12 @@ class _MapNodeState extends _JsonNodeState<_JsonViewerMapNode> {
 /// Display a list of JSON entries
 class _JsonViewerListNode extends _JsonNode<List<dynamic>> {
   const _JsonViewerListNode(
-    ResourceJsonTree root,
-    _JsonNode<dynamic>? parent,
-    String nodeName,
-    List<dynamic> nodeValue,
-    double leftOffset,
-    int expandedDepth, {
-    Key? key,
-  }) : super(
-          root,
-          parent,
-          nodeName,
-          nodeValue,
-          leftOffset,
-          expandedDepth,
-          key: key,
-        );
+    super.root,
+    super.parent,
+    super.nodeName,
+    super.nodeValue,
+    super.leftOffset,
+    super.expandedDepth,);
 
   @override
   State<StatefulWidget> createState() => _JsonViewerListNodeState();
@@ -235,16 +215,16 @@ class _JsonViewerListNodeState extends _JsonNodeState<_JsonViewerListNode> {
             ),
           Text(
             widget.nodeName,
-            style: Theme.of(context).textTheme.bodyText1,
+            style: Theme.of(context).textTheme.bodyLarge,
           ),
           Text(
             ' ($count)',
             style: (count > 0)
                 ? TextStyle(
-                    color: themeData.textTheme.bodyText1?.color
+                    color: themeData.textTheme.bodyLarge?.color
                         ?.withOpacity(variant600Opacity),
                   )
-                : TextStyle(color: themeData.errorColor),
+                : TextStyle(color: themeData.colorScheme.error),
           ),
         ],
       ),
@@ -271,22 +251,21 @@ class _JsonViewerGenericNode extends StatelessWidget {
   final String nodeName;
   final dynamic nodeValue;
 
-  const _JsonViewerGenericNode(this.nodeName, this.nodeValue, {Key? key})
-      : super(key: key);
+  const _JsonViewerGenericNode(this.nodeName, this.nodeValue);
 
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
 
-    var color = themeData.textTheme.bodyText1?.color;
+    var color = themeData.textTheme.bodyLarge?.color;
     if (nodeValue == null) {
-      color = themeData.errorColor;
+      color = themeData.colorScheme.error;
     } else {
       switch (nodeValue.runtimeType) {
         case bool:
           color = (nodeValue as bool)
               ? themeData.colorScheme.secondary
-              : themeData.errorColor;
+              : themeData.colorScheme.error;
           break;
         case int:
           color = themeData.colorScheme.secondary;
@@ -309,7 +288,7 @@ class _JsonViewerGenericNode extends StatelessWidget {
           Text(
             nodeName,
             style: TextStyle(
-              color: themeData.textTheme.bodyText1?.color
+              color: themeData.textTheme.bodyLarge?.color
                   ?.withOpacity(variant600Opacity),
             ),
           ),

--- a/lib/l10n/src/fdash_localizations_ar.dart
+++ b/lib/l10n/src/fdash_localizations_ar.dart
@@ -5,7 +5,7 @@ import 'fdash_localizations.g.dart';
 
 /// The translations for Arabic (`ar`).
 class FDashLocalizationsAr extends FDashLocalizations {
-  FDashLocalizationsAr([String locale = 'ar']) : super(locale);
+  FDashLocalizationsAr([super.locale = 'ar']);
 
   @override
   String get validatorRequiredItem => 'هذا السؤال يحتاج إلى أن يكتمل.';

--- a/lib/l10n/src/fdash_localizations_de.dart
+++ b/lib/l10n/src/fdash_localizations_de.dart
@@ -5,7 +5,7 @@ import 'fdash_localizations.g.dart';
 
 /// The translations for German (`de`).
 class FDashLocalizationsDe extends FDashLocalizations {
-  FDashLocalizationsDe([String locale = 'de']) : super(locale);
+  FDashLocalizationsDe([super.locale = 'de']);
 
   @override
   String get validatorRequiredItem => 'Füllen sie dieses Pflichtfeld aus.';

--- a/lib/l10n/src/fdash_localizations_en.dart
+++ b/lib/l10n/src/fdash_localizations_en.dart
@@ -5,7 +5,7 @@ import 'fdash_localizations.g.dart';
 
 /// The translations for English (`en`).
 class FDashLocalizationsEn extends FDashLocalizations {
-  FDashLocalizationsEn([String locale = 'en']) : super(locale);
+  FDashLocalizationsEn([super.locale = 'en']);
 
   @override
   String get validatorRequiredItem => 'This question needs to be completed.';

--- a/lib/l10n/src/fdash_localizations_es.dart
+++ b/lib/l10n/src/fdash_localizations_es.dart
@@ -5,7 +5,7 @@ import 'fdash_localizations.g.dart';
 
 /// The translations for Spanish Castilian (`es`).
 class FDashLocalizationsEs extends FDashLocalizations {
-  FDashLocalizationsEs([String locale = 'es']) : super(locale);
+  FDashLocalizationsEs([super.locale = 'es']);
 
   @override
   String get validatorRequiredItem => 'Esta pregunta debe ser completada.';

--- a/lib/l10n/src/fdash_localizations_ja.dart
+++ b/lib/l10n/src/fdash_localizations_ja.dart
@@ -5,7 +5,7 @@ import 'fdash_localizations.g.dart';
 
 /// The translations for Japanese (`ja`).
 class FDashLocalizationsJa extends FDashLocalizations {
-  FDashLocalizationsJa([String locale = 'ja']) : super(locale);
+  FDashLocalizationsJa([super.locale = 'ja']);
 
   @override
   String get validatorRequiredItem => 'この質問は完了する必要があります。';

--- a/lib/observations/src/observation_value_view.dart
+++ b/lib/observations/src/observation_value_view.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:fhir/r4.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -48,10 +46,9 @@ class ObservationValueView extends StatelessWidget {
         _observation.component!.isNotEmpty) {
       final componentText = StringBuffer();
       String? currentUnit;
-      final componentIterator =
-          HasNextIterator(_observation.component!.iterator);
-      do {
-        final ObservationComponent component = componentIterator.next();
+      final componentIterator = _observation.component!.iterator;
+      while (componentIterator.moveNext()) {
+        final ObservationComponent component = componentIterator.current;
         final unitString =
             ' ${component.valueQuantity?.unit ?? unknownUnitText}';
         // Avoid duplicate output of same unit:
@@ -69,7 +66,7 @@ class ObservationValueView extends StatelessWidget {
         } else {
           componentText.write('$componentSeparator$valueString');
         }
-      } while (componentIterator.hasNext);
+      }
       componentText.write(currentUnit);
       valueWidget = Text(
         componentText.toString(),

--- a/lib/observations/src/observation_value_view.dart
+++ b/lib/observations/src/observation_value_view.dart
@@ -80,7 +80,7 @@ class ObservationValueView extends StatelessWidget {
         unknownValueText,
         style: valueStyle?.copyWith(
           fontWeight: FontWeight.bold,
-          color: Theme.of(context).errorColor,
+          color: Theme.of(context).colorScheme.error,
         ),
       );
     }

--- a/lib/questionnaires/model/aggregation/src/aggregator.dart
+++ b/lib/questionnaires/model/aggregation/src/aggregator.dart
@@ -15,10 +15,10 @@ abstract class Aggregator<T> extends ValueNotifier<T> {
   /// [autoAggregate] specifies whether it should attach listeners to the
   /// questionnaire and aggregate when the questionnaire changes.
   Aggregator(
-    T initialValue, {
+    super.initialValue, {
     required this.localizations,
     this.autoAggregate = true,
-  }) : super(initialValue);
+  });
 
   // ignore: use_setters_to_change_properties
   /// Initialize the aggregator.

--- a/lib/questionnaires/model/aggregation/src/total_score_aggregator.dart
+++ b/lib/questionnaires/model/aggregation/src/total_score_aggregator.dart
@@ -18,7 +18,7 @@ class TotalScoreAggregator extends Aggregator<Decimal> {
 
   late final QuestionItemModel? totalScoreItem;
   TotalScoreAggregator(
-      {required FDashLocalizations localizations, bool autoAggregate = true})
+      {required FDashLocalizations localizations, bool autoAggregate = true,})
       : super(
           Decimal(0),
           localizations: localizations,

--- a/lib/questionnaires/model/expression/src/fhirpath_expression_evaluator.dart
+++ b/lib/questionnaires/model/expression/src/fhirpath_expression_evaluator.dart
@@ -31,7 +31,7 @@ class FhirPathExpressionEvaluator extends FhirExpressionEvaluator {
         ) {
     if (fhirPathExpression.language != ExpressionLanguage.text_fhirpath) {
       throw ArgumentError(
-        '$name has wrong language: ${fhirPathExpression.language.toString()}',
+        '$name has wrong language: ${fhirPathExpression.language}',
       );
     }
 

--- a/lib/questionnaires/model/item/answer/src/attachment_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/attachment_answer_model.dart
@@ -12,13 +12,13 @@ class AttachmentAnswerModel extends AnswerModel<Attachment, Attachment> {
   AttachmentAnswerModel(super.responseModel)
       : maxSize = responseModel.questionnaireItem.extension_
                 ?.extensionOrNull(
-                    'http://hl7.org/fhir/StructureDefinition/maxSize')
+                    'http://hl7.org/fhir/StructureDefinition/maxSize',)
                 ?.valueDecimal
                 ?.value ??
             0,
         mimeTypes = responseModel.questionnaireItem.extension_
                 ?.whereExtensionIs(
-                    'http://hl7.org/fhir/StructureDefinition/mimeType')
+                    'http://hl7.org/fhir/StructureDefinition/mimeType',)
                 ?.map((ext) => ext.valueCode?.value ?? '')
                 .where((mimeType) => mimeType != '')
                 .toList() ??

--- a/lib/questionnaires/model/item/answer/src/coding_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/coding_answer_model.dart
@@ -234,7 +234,7 @@ class CodingAnswerModel extends AnswerModel<OptionsOrString, OptionsOrString> {
 
   String? get _openLabel => qi.extension_
       ?.extensionOrNull(
-          'http://hl7.org/fhir/uv/sdc/StructureDefinition/questionnaire-sdc-openLabel')
+          'http://hl7.org/fhir/uv/sdc/StructureDefinition/questionnaire-sdc-openLabel',)
       ?.valueString;
 
   Iterable<RenderingString> toDisplay({bool includeMedia = true}) {

--- a/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
+++ b/lib/questionnaires/model/item/answer/src/numerical_answer_model.dart
@@ -153,7 +153,7 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
 
     qi.extension_
         ?.whereExtensionIs(
-            'http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption')
+            'http://hl7.org/fhir/StructureDefinition/questionnaire-unitOption',)
         ?.forEach((extension) {
       final coding = extension.valueCoding;
       if (coding == null) return;
@@ -163,10 +163,11 @@ class NumericalAnswerModel extends AnswerModel<String, Quantity> {
     // Using updated usage for questionnaire-unit in R5 (http://hl7.org/fhir/extensions/StructureDefinition-questionnaire-unit.html)
     final questionnaireUnit = qi.extension_
         ?.extensionOrNull(
-            'http://hl7.org/fhir/StructureDefinition/questionnaire-unit')
+            'http://hl7.org/fhir/StructureDefinition/questionnaire-unit',)
         ?.valueCoding;
-    if (questionnaireUnit != null && questionnaireUnit.display != null)
+    if (questionnaireUnit != null && questionnaireUnit.display != null) {
       _units[keyForUnitChoice(questionnaireUnit)] = questionnaireUnit;
+    }
   }
 
   @override

--- a/lib/questionnaires/model/item/src/question_item_model.dart
+++ b/lib/questionnaires/model/item/src/question_item_model.dart
@@ -178,7 +178,7 @@ class QuestionItemModel extends ResponseItemModel {
     // Non-existent answer models can be invalid, e.g. if minOccurs is not met.
     _ensureAnswerModel();
 
-    List<ValidationError> errors = super.validate(
+    final errors = super.validate(
       updateErrorText: updateErrorText,
       notifyListeners: notifyListeners,
     );

--- a/lib/questionnaires/model/src/questionnaire_item_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_item_model.dart
@@ -268,7 +268,7 @@ class QuestionnaireItemModel with Diagnosticable {
   /// The name of a section, the text of a question or text content for a display item.
   RenderingString? get text {
     final plainText = questionnaireItem.text?.translate(
-        questionnaireItem.textElement?.extension_, questionnaireModel.locale);
+        questionnaireItem.textElement?.extension_, questionnaireModel.locale,);
 
     return (plainText != null)
         ? RenderingString.fromText(

--- a/lib/questionnaires/model/src/questionnaire_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_model.dart
@@ -268,7 +268,7 @@ class QuestionnaireModel {
             final codeSystem =
                 getResource(valueSetInclude.system.toString()) as CodeSystem;
             _logger.debug(
-              'Processing included CodeSystem ${codeSystem.url.toString()}',
+              'Processing included CodeSystem ${codeSystem.url}',
             );
             if (codeSystem.concept != null) {
               for (final concept in codeSystem.concept!) {

--- a/lib/questionnaires/model/src/questionnaire_response_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_response_model.dart
@@ -862,7 +862,7 @@ class QuestionnaireResponseModel {
     bool updateErrorText = true,
     bool notifyListeners = false,
   }) {
-    List<ValidationError> validationErrors = [];
+    final List<ValidationError> validationErrors = [];
 
     for (final itemModel in orderedResponseItemModels()) {
       final errors = itemModel.validate(

--- a/lib/questionnaires/model/src/validation_errors/common_validation_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/common_validation_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class CommonValidationError extends ValidationError {
   final String? message;
-  const CommonValidationError(String nodeUid, this.message) : super(nodeUid);
+  const CommonValidationError(super.nodeUid, this.message);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/constraint_validation_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/constraint_validation_error.dart
@@ -3,8 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class ConstraintValidationError extends ValidationError {
   final String? message;
-  const ConstraintValidationError(String nodeUid, this.message)
-      : super(nodeUid);
+  const ConstraintValidationError(super.nodeUid, this.message);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/entry_format_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/entry_format_error.dart
@@ -4,7 +4,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 class EntryFormatError extends ValidationError {
   final String entryFormat;
 
-  const EntryFormatError(String nodeUid, this.entryFormat) : super(nodeUid);
+  const EntryFormatError(super.nodeUid, this.entryFormat);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/max_length_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/max_length_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MaxLengthError extends ValidationError {
   final int maxLength;
-  MaxLengthError(String nodeUid, this.maxLength) : super(nodeUid);
+  MaxLengthError(super.nodeUid, this.maxLength);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/max_occurs_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/max_occurs_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MaxOccursError extends ValidationError {
   final int maxOccurs;
-  MaxOccursError(String nodeUid, this.maxOccurs) : super(nodeUid);
+  MaxOccursError(super.nodeUid, this.maxOccurs);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/max_size_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/max_size_error.dart
@@ -4,7 +4,7 @@ import 'package:filesize/filesize.dart';
 
 class MaxSizeError extends ValidationError {
   final size;
-  MaxSizeError(String nodeUid, this.size) : super(nodeUid);
+  MaxSizeError(super.nodeUid, this.size);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/max_size_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/max_size_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 import 'package:filesize/filesize.dart';
 
 class MaxSizeError extends ValidationError {
-  final size;
+  final num size;
   MaxSizeError(super.nodeUid, this.size);
 
   @override

--- a/lib/questionnaires/model/src/validation_errors/max_value_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/max_value_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MaxValueError extends ValidationError {
   final String maxValue;
-  MaxValueError(String nodeUid, this.maxValue) : super(nodeUid);
+  MaxValueError(super.nodeUid, this.maxValue);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/mime_types_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/mime_types_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MimeTypesError extends ValidationError {
   final List<String> mimeTypes;
-  MimeTypesError(String nodeUid, this.mimeTypes) : super(nodeUid);
+  MimeTypesError(super.nodeUid, this.mimeTypes);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/min_length_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/min_length_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MinLengthError extends ValidationError {
   final int minLength;
-  MinLengthError(String nodeUid, this.minLength) : super(nodeUid);
+  MinLengthError(super.nodeUid, this.minLength);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/min_occurs_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/min_occurs_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MinOccursError extends ValidationError {
   final int minOccurs;
-  MinOccursError(String nodeUid, this.minOccurs) : super(nodeUid);
+  MinOccursError(super.nodeUid, this.minOccurs);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/min_value_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/min_value_error.dart
@@ -3,7 +3,7 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 
 class MinValueError extends ValidationError {
   final String minValue;
-  MinValueError(String nodeUid, this.minValue) : super(nodeUid);
+  MinValueError(super.nodeUid, this.minValue);
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/model/src/validation_errors/single_selection_or_open_string_error.dart
+++ b/lib/questionnaires/model/src/validation_errors/single_selection_or_open_string_error.dart
@@ -4,9 +4,9 @@ import 'package:faiadashu/questionnaires/model/src/validation_errors/validation_
 class SingleSelectionOrOpenStringError extends ValidationError {
   final String? openLabel;
   SingleSelectionOrOpenStringError(
-    String nodeUid,
+    super.nodeUid,
     this.openLabel,
-  ) : super(nodeUid);
+  );
 
   @override
   String? getMessage(FDashLocalizations localizations) {

--- a/lib/questionnaires/view/item/answer/src/attachment_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/attachment_answer_filler.dart
@@ -33,12 +33,9 @@ class _AttachmentAnswerState extends QuestionnaireAnswerFillerState<Attachment,
 class _AttachmentInputControl
     extends AnswerInputControl<AttachmentAnswerModel> {
   const _AttachmentInputControl(
-    AttachmentAnswerModel answerModel, {
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-        );
+    super.answerModel, {
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/questionnaires/view/item/answer/src/boolean_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/boolean_answer_filler.dart
@@ -31,12 +31,9 @@ class _BooleanItemState extends QuestionnaireAnswerFillerState<Boolean,
 
 class _BooleanInputControl extends AnswerInputControl<BooleanAnswerModel> {
   const _BooleanInputControl(
-    BooleanAnswerModel answerModel, {
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-        );
+    super.answerModel, {
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +48,7 @@ class _BooleanInputControl extends AnswerInputControl<BooleanAnswerModel> {
           activeColor:
               (answerModel.displayErrorText(FDashLocalizations.of(context)) !=
                       null)
-                  ? Theme.of(context).errorColor
+                  ? Theme.of(context).colorScheme.error
                   : null,
           tristate: answerModel.isTriState,
           onChanged: (answerModel.isControlEnabled)
@@ -71,8 +68,8 @@ class _BooleanInputControl extends AnswerInputControl<BooleanAnswerModel> {
             answerModel.displayErrorText(FDashLocalizations.of(context))!,
             style: Theme.of(context)
                 .textTheme
-                .caption!
-                .copyWith(color: Theme.of(context).errorColor),
+                .bodySmall!
+                .copyWith(color: Theme.of(context).colorScheme.error),
           ),
       ],
     );

--- a/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
@@ -32,14 +32,9 @@ class _CodingAnswerState extends QuestionnaireAnswerFillerState<OptionsOrString,
 
 class _CodingInputControl extends AnswerInputControl<CodingAnswerModel> {
   const _CodingInputControl(
-    CodingAnswerModel answerModel, {
-    Key? key,
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          key: key,
-          focusNode: focusNode,
-        );
+    super.answerModel, {
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -114,9 +109,7 @@ class _StyledOption extends StatefulWidget {
 
   const _StyledOption(
     this.answerModel,
-    this.optionModel, {
-    Key? key,
-  }) : super(key: key);
+    this.optionModel,);
 
   @override
   _StyledOptionState createState() => _StyledOptionState();
@@ -182,8 +175,7 @@ class _CheckboxChoice extends StatelessWidget {
   final CodingAnswerOptionModel answerOption;
   final CodingAnswerModel answerModel;
 
-  const _CheckboxChoice(this.answerModel, this.answerOption, {Key? key})
-      : super(key: key);
+  const _CheckboxChoice(this.answerModel, this.answerOption);
 
   @override
   Widget build(BuildContext context) {
@@ -217,7 +209,7 @@ class _CheckboxChoice extends StatelessWidget {
 class _NullRadioChoice extends StatelessWidget {
   final CodingAnswerModel answerModel;
 
-  const _NullRadioChoice(this.answerModel, {Key? key}) : super(key: key);
+  const _NullRadioChoice(this.answerModel);
 
   @override
   Widget build(BuildContext context) {
@@ -241,8 +233,7 @@ class _RadioChoice extends StatelessWidget {
   final CodingAnswerOptionModel answerOption;
   final CodingAnswerModel answerModel;
 
-  const _RadioChoice(this.answerModel, this.answerOption, {Key? key})
-      : super(key: key);
+  const _RadioChoice(this.answerModel, this.answerOption);
 
   @override
   Widget build(BuildContext context) {
@@ -272,14 +263,9 @@ class _RadioChoice extends StatelessWidget {
 
 class _CodingDropdown extends AnswerInputControl<CodingAnswerModel> {
   const _CodingDropdown(
-    CodingAnswerModel answerModel, {
-    Key? key,
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          key: key,
-          focusNode: focusNode,
-        );
+    super.answerModel, {
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -325,15 +311,10 @@ class _CodingDropdown extends AnswerInputControl<CodingAnswerModel> {
 
 class _VerticalCodingChoices extends AnswerInputControl<CodingAnswerModel> {
   const _VerticalCodingChoices(
-    CodingAnswerModel answerModel,
+    super.answerModel,
     this.choices, {
-    Key? key,
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          key: key,
-          focusNode: focusNode,
-        );
+    super.focusNode,
+  });
 
   final List<Widget> choices;
 
@@ -360,14 +341,9 @@ class _CodingChoices extends AnswerInputControl<CodingAnswerModel> {
   late final List<Widget> _choices;
 
   _CodingChoices(
-    CodingAnswerModel answerModel, {
-    Key? key,
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-          key: key,
-        ) {
+    super.answerModel, {
+    super.focusNode,
+  }) {
     _choices = _createChoices();
   }
 
@@ -420,15 +396,10 @@ class _CodingChoices extends AnswerInputControl<CodingAnswerModel> {
 
 class _HorizontalCodingChoices extends AnswerInputControl<CodingAnswerModel> {
   const _HorizontalCodingChoices(
-    CodingAnswerModel answerModel,
+    super.answerModel,
     this.choices, {
-    Key? key,
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-          key: key,
-        );
+    super.focusNode,
+  });
 
   final List<Widget> choices;
 
@@ -465,8 +436,7 @@ class _CodingChoiceDecorator extends StatelessWidget {
     this.answerModel, {
     this.focusNode,
     this.child,
-    Key? key,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -510,14 +480,9 @@ class _CodingChoiceDecorator extends StatelessWidget {
 
 class _CodingAutoComplete extends AnswerInputControl<CodingAnswerModel> {
   const _CodingAutoComplete(
-    CodingAnswerModel answerModel, {
-    Key? key,
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          key: key,
-          focusNode: focusNode,
-        );
+    super.answerModel, {
+    super.focusNode,
+  });
 
   Widget _fieldViewBuilder(
     BuildContext context,
@@ -574,7 +539,7 @@ class _CodingAutoComplete extends AnswerInputControl<CodingAnswerModel> {
 class _OpenStringInputControl extends StatefulWidget {
   final CodingAnswerModel answerModel;
 
-  const _OpenStringInputControl(this.answerModel, {Key? key}) : super(key: key);
+  const _OpenStringInputControl(this.answerModel);
 
   @override
   _OpenStringInputControlState createState() => _OpenStringInputControlState();
@@ -601,7 +566,7 @@ class _OpenStringInputControlState extends State<_OpenStringInputControl> {
           answerModel.getOpenLabel(FDashLocalizations.of(context)),
           defaultTextStyle: Theme.of(context)
               .textTheme
-              .bodyText2
+              .bodyMedium
               ?.copyWith(fontWeight: FontWeight.w500),
         ),
         const SizedBox(
@@ -634,12 +599,11 @@ class _OpenStringInputControlState extends State<_OpenStringInputControl> {
 
 class _FDashAutocompleteField extends StatelessWidget {
   const _FDashAutocompleteField({
-    Key? key,
     required this.answerModel,
     required this.focusNode,
     required this.textEditingController,
     required this.onFieldSubmitted,
-  }) : super(key: key);
+  });
 
   final AnswerModel answerModel;
 

--- a/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
@@ -33,12 +33,9 @@ class _DateTimeAnswerState extends QuestionnaireAnswerFillerState<FhirDateTime,
 
 class _DateTimeInputControl extends AnswerInputControl<DateTimeAnswerModel> {
   const _DateTimeInputControl(
-    DateTimeAnswerModel answerModel, {
-    FocusNode? focusNode,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-        );
+    super.answerModel, {
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +66,7 @@ class _DateTimeInputControl extends AnswerInputControl<DateTimeAnswerModel> {
         errorStyle: (itemModel
                 .isCalculated) // Force display of error text on calculated item
             ? TextStyle(
-                color: Theme.of(context).errorColor,
+                color: Theme.of(context).colorScheme.error,
               )
             : null,
       ),

--- a/lib/questionnaires/view/item/answer/src/null_dash_text.dart
+++ b/lib/questionnaires/view/item/answer/src/null_dash_text.dart
@@ -2,17 +2,17 @@ import 'package:faiadashu/questionnaires/view/view.dart' show variant600Opacity;
 import 'package:flutter/material.dart';
 
 class NullDashText extends StatelessWidget {
-  const NullDashText({Key? key}) : super(key: key);
+  const NullDashText({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Text(
       '   ',
-      style: Theme.of(context).textTheme.bodyText2?.copyWith(
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
             decoration: TextDecoration.lineThrough,
             color: Theme.of(context)
                 .textTheme
-                .bodyText2!
+                .bodyMedium!
                 .color!
                 .withOpacity(variant600Opacity),
           ),

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -67,15 +67,10 @@ class _SliderInputControl extends AnswerInputControl<NumericalAnswerModel> {
   final ValueNotifier<double> sliderValueDuringChange;
 
   const _SliderInputControl(
-    NumericalAnswerModel answerModel, {
+    super.answerModel, {
     required this.sliderValueDuringChange,
-    FocusNode? focusNode,
-    Key? key,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-          key: key,
-        );
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -131,14 +126,14 @@ class _SliderInputControl extends AnswerInputControl<NumericalAnswerModel> {
                 Xhtml.fromRenderingString(
                   context,
                   lowerSliderLabel,
-                  defaultTextStyle: Theme.of(context).textTheme.button,
+                  defaultTextStyle: Theme.of(context).textTheme.labelLarge,
                 ),
               const Expanded(child: SizedBox()),
               if (upperSliderLabel != null)
                 Xhtml.fromRenderingString(
                   context,
                   upperSliderLabel,
-                  defaultTextStyle: Theme.of(context).textTheme.button,
+                  defaultTextStyle: Theme.of(context).textTheme.labelLarge,
                 ),
               const SizedBox(width: 8.0),
             ],
@@ -154,17 +149,11 @@ class _NumberFieldInputControl
   final TextInputFormatter numberInputFormatter;
 
   _NumberFieldInputControl(
-    NumericalAnswerModel answerModel, {
+    super.answerModel, {
     required this.editingController,
-    FocusNode? focusNode,
-    Key? key,
+    super.focusNode,
   })  : numberInputFormatter =
-            NumericalTextInputFormatter(answerModel.numberFormat),
-        super(
-          answerModel,
-          focusNode: focusNode,
-          key: key,
-        );
+            NumericalTextInputFormatter(answerModel.numberFormat);
 
   @override
   Widget build(BuildContext context) {
@@ -202,7 +191,7 @@ class _NumberFieldInputControl
               errorStyle: (itemModel
                       .isCalculated) // Force display of error text on calculated item
                   ? TextStyle(
-                      color: Theme.of(context).errorColor,
+                      color: Theme.of(context).colorScheme.error,
                     )
                   : null,
               hintText: answerModel.entryFormat,
@@ -211,7 +200,7 @@ class _NumberFieldInputControl
                       Icons.calculate,
                       color:
                           (answerModel.displayErrorText(localizations) != null)
-                              ? Theme.of(context).errorColor
+                              ? Theme.of(context).colorScheme.error
                               : null,
                     )
                   : null,
@@ -260,8 +249,8 @@ class _NumberFieldInputControl
 
 class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
   const _UnitDropDown(
-    NumericalAnswerModel answerModel,
-  ) : super(answerModel);
+    super.answerModel,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -274,7 +263,7 @@ class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
             width: unitWidth,
             child: Text(
               answerModel.unitChoices.first.localizedDisplay(locale),
-              style: Theme.of(context).textTheme.subtitle1,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
           )
         : Container(

--- a/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/numerical_answer_filler.dart
@@ -286,7 +286,7 @@ class _UnitDropDown extends AnswerInputControl<NumericalAnswerModel> {
                       value: answerModel.keyForUnitChoice(value),
                       child: Text(value.localizedDisplay(locale)),
                     );
-                  }).toList(),
+                  }),
                 ],
               ),
             ),

--- a/lib/questionnaires/view/item/answer/src/string_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/string_answer_filler.dart
@@ -48,15 +48,10 @@ class _StringAnswerInputControl extends AnswerInputControl<StringAnswerModel> {
   final TextEditingController editingController;
 
   const _StringAnswerInputControl(
-    StringAnswerModel answerModel, {
+    super.answerModel, {
     required this.editingController,
-    FocusNode? focusNode,
-    Key? key,
-  }) : super(
-          answerModel,
-          focusNode: focusNode,
-          key: key,
-        );
+    super.focusNode,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -100,7 +95,7 @@ class _StringAnswerInputControl extends AnswerInputControl<StringAnswerModel> {
         errorStyle: (itemModel
                 .isCalculated) // Force display of error text on calculated item
             ? TextStyle(
-                color: Theme.of(context).errorColor,
+                color: Theme.of(context).colorScheme.error,
               )
             : null,
         hintText: answerModel.entryFormat,
@@ -108,7 +103,7 @@ class _StringAnswerInputControl extends AnswerInputControl<StringAnswerModel> {
             ? Icon(
                 Icons.calculate,
                 color: (answerModel.displayErrorText(locale) != null)
-                    ? Theme.of(context).errorColor
+                    ? Theme.of(context).colorScheme.error
                     : null,
               )
             : null,

--- a/lib/questionnaires/view/item/src/display_item.dart
+++ b/lib/questionnaires/view/item/src/display_item.dart
@@ -5,10 +5,10 @@ import 'package:flutter/material.dart';
 /// A view for filler items of type "display".
 class DisplayItem extends QuestionnaireItemFiller {
   DisplayItem(
-    QuestionnaireFillerData questionnaireFiller,
-    FillerItemModel fillerItem, {
-    Key? key,
-  }) : super(questionnaireFiller, fillerItem, key: key);
+    super.questionnaireFiller,
+    super.fillerItem, {
+    super.key,
+  });
   @override
   State<StatefulWidget> createState() => _DisplayItemState();
 }

--- a/lib/questionnaires/view/item/src/group_item.dart
+++ b/lib/questionnaires/view/item/src/group_item.dart
@@ -6,10 +6,10 @@ import 'package:flutter/material.dart';
 /// A view for filler items of type "group".
 class GroupItem extends ResponseItemFiller {
   GroupItem(
-    QuestionnaireFillerData questionnaireFiller,
-    ResponseItemModel responseItemModel, {
-    Key? key,
-  }) : super(questionnaireFiller, responseItemModel, key: key);
+    super.questionnaireFiller,
+    super.responseItemModel, {
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() => _GroupItemState();

--- a/lib/questionnaires/view/item/src/item_media_image.dart
+++ b/lib/questionnaires/view/item/src/item_media_image.dart
@@ -11,7 +11,7 @@ class ItemMediaImage extends StatelessWidget {
 
   final Widget itemImageWidget;
 
-  const ItemMediaImage._(this.itemImageWidget, {Key? key}) : super(key: key);
+  const ItemMediaImage._(this.itemImageWidget);
 
   static Widget? fromItemMedia(
     ItemMediaModel? itemMediaModel, {

--- a/lib/questionnaires/view/item/src/question_response_item_filler.dart
+++ b/lib/questionnaires/view/item/src/question_response_item_filler.dart
@@ -153,9 +153,7 @@ class _HorizontalAnswerFillers extends StatefulWidget {
 
   const _HorizontalAnswerFillers(
     this.questionResponseItemModel,
-    this.questionnaireTheme, {
-    Key? key,
-  }) : super(key: key);
+    this.questionnaireTheme,);
 
   @override
   _HorizontalAnswerFillersState createState() =>

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -10,9 +10,8 @@ abstract class QuestionnaireItemFiller extends StatefulWidget {
   QuestionnaireItemFiller(
     QuestionnaireFillerData questionnaireFiller,
     this.fillerItemModel, {
-    Key? key,
-  })  : questionnaireTheme = questionnaireFiller.questionnaireTheme,
-        super(key: key);
+    super.key,
+  })  : questionnaireTheme = questionnaireFiller.questionnaireTheme;
 }
 
 abstract class QuestionnaireItemFillerState<W extends QuestionnaireItemFiller>

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler_title.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler_title.dart
@@ -15,8 +15,8 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
     this.leading,
     this.help,
     required this.semanticsLabel,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   static Widget? fromFillerItem({
     required FillerItemModel fillerItem,
@@ -51,8 +51,8 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
       final title = text.xhtmlText;
 
       final htmlTitleText = (prefixText != null)
-          ? '$openStyleTag${prefixText.xhtmlText}&nbsp;${title}$requiredTag$closeStyleTag'
-          : '$openStyleTag${title}$requiredTag$closeStyleTag';
+          ? '$openStyleTag${prefixText.xhtmlText}&nbsp;$title$requiredTag$closeStyleTag'
+          : '$openStyleTag$title$requiredTag$closeStyleTag';
 
       return QuestionnaireItemFillerTitle._(
         htmlTitleText: htmlTitleText,
@@ -91,7 +91,7 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
                   toTextSpan(
                     context,
                     htmlTitleText,
-                    defaultTextStyle: Theme.of(context).textTheme.bodyText2,
+                    defaultTextStyle: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ],
               ),
@@ -132,7 +132,7 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
 class _QuestionnaireItemFillerHelp extends StatefulWidget {
   final QuestionnaireItemModel ql;
 
-  const _QuestionnaireItemFillerHelp(this.ql, {Key? key}) : super(key: key);
+  const _QuestionnaireItemFillerHelp(this.ql, {super.key});
 
   @override
   State<StatefulWidget> createState() => _QuestionnaireItemFillerHelpState();
@@ -163,7 +163,7 @@ class _QuestionnaireItemFillerHelpState
           content: Xhtml.fromRenderingString(
             context,
             questionnaireItemModel.text ?? RenderingString.nullText,
-            defaultTextStyle: Theme.of(context).textTheme.bodyText2,
+            defaultTextStyle: Theme.of(context).textTheme.bodyMedium,
           ),
           actions: <Widget>[
             OutlinedButton(
@@ -185,8 +185,7 @@ class _QuestionnaireItemFillerSupportLink extends StatelessWidget {
   static final _logger = Logger(_QuestionnaireItemFillerSupportLink);
   final Uri supportLink;
 
-  const _QuestionnaireItemFillerSupportLink(this.supportLink, {Key? key})
-      : super(key: key);
+  const _QuestionnaireItemFillerSupportLink(this.supportLink, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -194,7 +193,7 @@ class _QuestionnaireItemFillerSupportLink extends StatelessWidget {
       mouseCursor: SystemMouseCursors.help,
       icon: const Icon(Icons.help),
       onPressed: () {
-        _logger.debug("supportLink '${supportLink.toString()}'");
+        _logger.debug("supportLink '$supportLink'");
         QuestionnaireResponseFiller.of(context)
             .onLinkTap
             ?.call(context, supportLink);
@@ -205,9 +204,8 @@ class _QuestionnaireItemFillerSupportLink extends StatelessWidget {
 
 class _QuestionnaireItemFillerTitleLeading extends StatelessWidget {
   final Widget _leadingWidget;
-  const _QuestionnaireItemFillerTitleLeading._(Widget leadingWidget, {Key? key})
-      : _leadingWidget = leadingWidget,
-        super(key: key);
+  const _QuestionnaireItemFillerTitleLeading._(Widget leadingWidget)
+      : _leadingWidget = leadingWidget;
 
   static Widget? fromFillerItem(
     FillerItemModel fillerItemModel, {

--- a/lib/questionnaires/view/item/src/total_score_item.dart
+++ b/lib/questionnaires/view/item/src/total_score_item.dart
@@ -12,9 +12,9 @@ import 'package:simple_html_css/simple_html_css.dart';
 /// sundhed.dk questionnaire-feedback extension.
 class TotalScoreItem extends QuestionnaireAnswerFiller {
   TotalScoreItem(
-    AnswerModel answerModel, {
-    Key? key,
-  }) : super(answerModel, key: key);
+    super.answerModel, {
+    super.key,
+  });
   @override
   State<StatefulWidget> createState() => _TotalScoreItemState();
 }
@@ -107,14 +107,14 @@ class _TotalScoreItemState extends State<TotalScoreItem> {
             const SizedBox(height: 32),
             Text(
               FDashLocalizations.of(context).aggregationTotalScoreTitle,
-              style: Theme.of(context).textTheme.headline3,
+              style: Theme.of(context).textTheme.displaySmall,
             ),
             AnimatedSwitcher(
               duration: const Duration(milliseconds: 200),
               child: Text(
                 scoreText,
                 key: ValueKey<String>(scoreText),
-                style: Theme.of(context).textTheme.headline1,
+                style: Theme.of(context).textTheme.displayLarge,
               ),
             ),
             AnimatedSwitcher(

--- a/lib/questionnaires/view/src/broken_questionnaire_item.dart
+++ b/lib/questionnaires/view/src/broken_questionnaire_item.dart
@@ -15,12 +15,12 @@ class BrokenQuestionnaireItem extends StatelessWidget {
     this.message,
     this.element,
     this.cause, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   /// Construct the item from an exception.
   /// Special support for [QuestionnaireFormatException].
-  BrokenQuestionnaireItem.fromException(Object exception, {Key? key})
+  BrokenQuestionnaireItem.fromException(Object exception, {super.key})
       : message = (exception is QuestionnaireFormatException)
             ? exception.message
             : exception.toString(),
@@ -29,13 +29,12 @@ class BrokenQuestionnaireItem extends StatelessWidget {
             : null,
         cause = (exception is QuestionnaireFormatException)
             ? exception.cause
-            : null,
-        super(key: key);
+            : null;
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Theme.of(context).errorColor,
+      color: Theme.of(context).colorScheme.error,
       child: Container(
         padding: const EdgeInsets.all(8),
         child: Column(
@@ -44,13 +43,13 @@ class BrokenQuestionnaireItem extends StatelessWidget {
             if (cause != null)
               SelectableText(
                 cause.toString(),
-                style: Theme.of(context).textTheme.headline6?.copyWith(
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
                       color: Theme.of(context).cardColor,
                     ),
               ),
             SelectableText(
               message,
-              style: Theme.of(context).textTheme.subtitle1?.copyWith(
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     color: Colors.yellow,
                   ),
             ),

--- a/lib/questionnaires/view/src/narrative_drawer.dart
+++ b/lib/questionnaires/view/src/narrative_drawer.dart
@@ -9,7 +9,7 @@ import 'package:flutter/services.dart';
 /// "Drawer" which contains the narrative for a questionnaire.
 /// To be used with the drawer or endDrawer parameter of a [Scaffold].
 class NarrativeDrawer extends StatefulWidget {
-  const NarrativeDrawer({Key? key}) : super(key: key);
+  const NarrativeDrawer({super.key});
 
   @override
   State<StatefulWidget> createState() => _NarrativeDrawerState();
@@ -55,7 +55,7 @@ class _NarrativeDrawerState extends State<NarrativeDrawer> {
                       !_drawerMode
                           ? FDashLocalizations.of(context).narrativePageTitle
                           : 'FHIR R4 JSON',
-                      style: Theme.of(context).textTheme.headline5,
+                      style: Theme.of(context).textTheme.headlineSmall,
                     ),
                     secondary: IconButton(
                       icon: const Icon(Icons.copy),

--- a/lib/questionnaires/view/src/narrative_page.dart
+++ b/lib/questionnaires/view/src/narrative_page.dart
@@ -15,8 +15,8 @@ class NarrativePage extends StatelessWidget {
   const NarrativePage({
     this.questionnaireResponseModel,
     this.narrative,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/questionnaires/view/src/narrative_tile.dart
+++ b/lib/questionnaires/view/src/narrative_tile.dart
@@ -22,8 +22,8 @@ class NarrativeTile extends StatefulWidget {
   const NarrativeTile({
     this.questionnaireResponseModel,
     this.narrative,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() => _NarrativeTileState();

--- a/lib/questionnaires/view/src/questionnaire_complete_button.dart
+++ b/lib/questionnaires/view/src/questionnaire_complete_button.dart
@@ -11,8 +11,7 @@ import 'package:flutter/material.dart';
 class QuestionnaireCompleteButton extends StatefulWidget {
   final VoidCallback? onCompleted;
 
-  const QuestionnaireCompleteButton({this.onCompleted, Key? key})
-      : super(key: key);
+  const QuestionnaireCompleteButton({this.onCompleted, super.key});
 
   @override
   // ignore: library_private_types_in_public_api

--- a/lib/questionnaires/view/src/questionnaire_filler.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler.dart
@@ -33,10 +33,10 @@ class QuestionnaireResponseFiller extends StatefulWidget {
           fhirResourceProvider: fhirResourceProvider,
           launchContext: launchContext,
           questionnaireModelDefaults: questionnaireModelDefaults,
-          localizations: FDashLocalizations.of(context));
+          localizations: FDashLocalizations.of(context),);
 
   const QuestionnaireResponseFiller({
-    Key? key,
+    super.key,
     required this.builder,
     required this.fhirResourceProvider,
     required this.launchContext,
@@ -45,7 +45,7 @@ class QuestionnaireResponseFiller extends StatefulWidget {
     this.onLinkTap,
     this.questionnaireTheme = const QuestionnaireThemeData(),
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
-  }) : super(key: key);
+  });
 
   static QuestionnaireFillerData of(BuildContext context) {
     final result =
@@ -202,7 +202,6 @@ class QuestionnaireFillerData extends InheritedWidget {
 
   QuestionnaireFillerData._(
     this.questionnaireResponseModel, {
-    Key? key,
     this.onDataAvailable,
     this.onLinkTap,
     required this.questionnaireTheme,
@@ -213,7 +212,7 @@ class QuestionnaireFillerData extends InheritedWidget {
           questionnaireResponseModel.orderedFillerItemModels().length,
           null,
         ),
-        super(key: key, child: Builder(builder: builder)) {
+        super(child: Builder(builder: builder)) {
     _logger.trace('constructor _');
     onDataAvailable?.call(questionnaireResponseModel);
   }

--- a/lib/questionnaires/view/src/questionnaire_filler_circular_progress.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler_circular_progress.dart
@@ -14,8 +14,8 @@ class QuestionnaireFillerCircularProgress extends StatelessWidget {
 
   const QuestionnaireFillerCircularProgress({
     this.radius = defaultRadius,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/questionnaires/view/src/questionnaire_filler_progress_bar.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler_progress_bar.dart
@@ -13,8 +13,8 @@ class QuestionnaireFillerProgressBar extends StatelessWidget {
     this.height = defaultHeight,
     this.answeredColor,
     this.unansweredColor,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/questionnaires/view/src/questionnaire_information_tile.dart
+++ b/lib/questionnaires/view/src/questionnaire_information_tile.dart
@@ -8,12 +8,11 @@ import 'package:flutter/material.dart';
 /// Contains information such as title and publisher.
 class QuestionnaireInformationTile extends StatelessWidget {
   final Questionnaire questionnaire;
-  const QuestionnaireInformationTile(this.questionnaire, {Key? key})
-      : super(key: key);
+  const QuestionnaireInformationTile(this.questionnaire, {super.key});
 
   @override
   Widget build(BuildContext context) {
-    final defaultTextStyle = Theme.of(context).textTheme.subtitle1;
+    final defaultTextStyle = Theme.of(context).textTheme.titleMedium;
 
     return Column(
       children: [

--- a/lib/questionnaires/view/src/questionnaire_loading_indicator.dart
+++ b/lib/questionnaires/view/src/questionnaire_loading_indicator.dart
@@ -10,13 +10,12 @@ class QuestionnaireLoadingIndicator extends StatelessWidget {
 
   QuestionnaireLoadingIndicator(
     AsyncSnapshot<QuestionnaireResponseModel> snapshot, {
-    Key? key,
+    super.key,
   })  : state = snapshot.connectionState,
         hasError = snapshot.hasError,
         detail = (snapshot.hasData)
             ? snapshot.data?.questionnaireModel.title
-            : snapshot.error,
-        super(key: key);
+            : snapshot.error;
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +46,7 @@ class QuestionnaireLoadingIndicator extends StatelessWidget {
           if (detail != null)
             Text(
               detail.toString(),
-              style: Theme.of(context).textTheme.subtitle1,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
         ],
       ),

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -44,8 +44,8 @@ class QuestionnaireScroller extends StatefulWidget {
     this.onLinkTap,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
     this.onQuestionnaireResponseChanged,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/questionnaires/view/src/questionnaire_scroller_page.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller_page.dart
@@ -22,8 +22,8 @@ class QuestionnaireScrollerPage extends StatelessWidget {
     this.aggregators,
     this.onLinkTap,
     this.questionnaireModelDefaults = const QuestionnaireModelDefaults(),
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -93,7 +93,7 @@ class QuestionnaireStepperState extends State<QuestionnaireStepper> {
                                   FDashLocalizations.of(context)
                                       .aggregationScore(scoreString),
                                   key: ValueKey<String>(scoreString),
-                                  style: Theme.of(context).textTheme.headline4,
+                                  style: Theme.of(context).textTheme.headlineMedium,
                                 ),
                               );
                             },

--- a/lib/questionnaires/view/src/questionnaire_stepper_page.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page.dart
@@ -1,5 +1,4 @@
 import 'package:faiadashu/questionnaires/questionnaires.dart';
-import 'package:faiadashu/resource_provider/resource_provider.dart';
 import 'package:flutter/material.dart';
 
 /// A page, incl. a [Scaffold], that presents a questionnaire in the style of a wizard.
@@ -8,17 +7,12 @@ import 'package:flutter/material.dart';
 /// see [QuestionnaireScrollerPage]
 class QuestionnaireStepperPage extends QuestionnaireStepper {
   const QuestionnaireStepperPage({
-    required FhirResourceProvider fhirResourceProvider,
-    required LaunchContext launchContext,
-    QuestionnaireModelDefaults questionnaireModelDefaults =
-        const QuestionnaireModelDefaults(),
-    Key? key,
+    required super.fhirResourceProvider,
+    required super.launchContext,
+    super.questionnaireModelDefaults,
+    super.key,
   }) : super(
           scaffoldBuilder: const DefaultQuestionnairePageScaffoldBuilder(),
-          fhirResourceProvider: fhirResourceProvider,
-          launchContext: launchContext,
-          questionnaireModelDefaults: questionnaireModelDefaults,
-          key: key,
         );
 
   @override

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -26,7 +26,7 @@ class QuestionnaireStepperPageView extends StatefulWidget {
   }
 
   @override
-  _QuestionnaireStepperPageViewState createState() =>
+  State<QuestionnaireStepperPageView> createState() =>
       _QuestionnaireStepperPageViewState();
 }
 
@@ -141,6 +141,7 @@ class QuestionnaireStepperPageViewController {
   /// Attaches the provided state to this controller.
   /// This internal method is used to establish a connection between the
   /// controller and the `_QuestionnaireStepperPageViewState`.
+  // ignore: use_setters_to_change_properties
   void _attach(_QuestionnaireStepperPageViewState state) {
     _state = state;
   }

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -21,7 +21,7 @@ class QuestionnaireStepperPageView extends StatefulWidget {
     final result = context.dependOnInheritedWidgetOfExactType<
         _QuestionnaireStepperPageViewInheritedWidget>();
     assert(result != null,
-        'No QuestionnaireStepperInheritedWidget found in context');
+        'No QuestionnaireStepperInheritedWidget found in context',);
     return result!.data;
   }
 
@@ -32,7 +32,7 @@ class QuestionnaireStepperPageView extends StatefulWidget {
 
 class _QuestionnaireStepperPageViewState
     extends State<QuestionnaireStepperPageView> {
-  PageController _pageController = PageController();
+  final PageController _pageController = PageController();
   bool _hasRequestsRunning = false;
   QuestionnaireItemFiller? _currentQuestionnaireItemFiller;
 
@@ -223,7 +223,6 @@ class _QuestionnaireStepperPageViewInheritedWidget extends InheritedWidget {
   final QuestionnaireStepperPageViewData data;
 
   const _QuestionnaireStepperPageViewInheritedWidget({
-    super.key,
     required super.child,
     required this.data,
   });

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -15,9 +15,9 @@ class QuestionnaireTheme extends InheritedWidget {
 
   const QuestionnaireTheme({
     required this.data,
-    required Widget child,
-    Key? key,
-  }) : super(key: key, child: child);
+    required super.child,
+    super.key,
+  });
 
   static QuestionnaireThemeData of(BuildContext context) {
     final inheritedTheme =
@@ -374,8 +374,8 @@ class QuestionnaireThemeData {
             padding: const EdgeInsets.only(top: 4.0),
             child: Text(
               errorText,
-              style: Theme.of(context).textTheme.subtitle1!.copyWith(
-                    color: Theme.of(context).errorColor,
+              style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                    color: Theme.of(context).colorScheme.error,
                   ),
             ),
           ),
@@ -416,8 +416,8 @@ class QuestionnaireThemeData {
             errorText,
             style: Theme.of(context)
                 .textTheme
-                .caption
-                ?.copyWith(color: Theme.of(context).errorColor),
+                .bodySmall
+                ?.copyWith(color: Theme.of(context).colorScheme.error),
           ),
       ],
     );

--- a/lib/questionnaires/view/src/webview_html.dart
+++ b/lib/questionnaires/view/src/webview_html.dart
@@ -12,7 +12,7 @@ Widget createWebView(String xhtml, {Key? key}) => _FullHtmlViewer(
 class _FullHtmlViewer extends StatelessWidget {
   final String xhtml;
 
-  const _FullHtmlViewer(this.xhtml, {Key? key}) : super(key: key);
+  const _FullHtmlViewer(this.xhtml, {super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/questionnaires/view/src/webview_io.dart
+++ b/lib/questionnaires/view/src/webview_io.dart
@@ -19,7 +19,7 @@ Widget createWebView(String xhtml, {Key? key}) =>
 class _FullHtmlViewer extends StatelessWidget {
   final String xhtml;
 
-  const _FullHtmlViewer(this.xhtml, {Key? key}) : super(key: key);
+  const _FullHtmlViewer(this.xhtml, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -40,7 +40,7 @@ class _FullHtmlViewer extends StatelessWidget {
 class _SimpleHtmlViewer extends StatelessWidget {
   final String xhtml;
 
-  const _SimpleHtmlViewer(this.xhtml, {Key? key}) : super(key: key);
+  const _SimpleHtmlViewer(this.xhtml, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +49,7 @@ class _SimpleHtmlViewer extends StatelessWidget {
         child: HTML.toRichText(
           context,
           xhtml,
-          defaultTextStyle: Theme.of(context).textTheme.bodyText2,
+          defaultTextStyle: Theme.of(context).textTheme.bodyMedium,
         ),
       ),
     );

--- a/lib/questionnaires/view/src/xhtml.dart
+++ b/lib/questionnaires/view/src/xhtml.dart
@@ -127,7 +127,7 @@ class Xhtml extends StatelessWidget {
             context,
             xhtml,
             defaultTextStyle:
-                defaultTextStyle ?? Theme.of(context).textTheme.bodyText2,
+                defaultTextStyle ?? Theme.of(context).textTheme.bodyMedium,
           ),
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  lint: ^1.8.2
+  lint: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Related to #68 

This PR does the following in preparation for updating the rest of the package dependencies:

* Updates the `lint` package to the latest version (2.1.2).
* Applies autofixes with `dart fix --apply`
  * These are most of the actual changes in this PR
* Addresses some of the leftover linter warnings given by `flutter analyze`

I'd recommend to review this PR commit by commit instead of all at once, as it'd make it easier to check the changes.