### PR TITLE
Update minor packages

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -639,42 +639,42 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter
-      sha256: "392c1d83b70fe2495de3ea2c84531268d5b8de2de3f01086a53334d8b6030a88"
+      sha256: c1ab9b81090705c6069197d9fdc1625e587b52b8d70cdde2339d177ad0dbb98e
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "4.4.1"
   webview_flutter_android:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: a465f6b274d62c930f1b89f48ad6bd9a7c7567533e13b817dc67a5c96e325bf5
+      sha256: b0cd33dd7d3dd8e5f664e11a19e17ba12c352647269921a3b568406b001f1dff
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.9"
+    version: "3.12.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "60828a1ae6a1ac779895768b5567aea1157e1b0b58660ce67c6da30ae56694ec"
+      sha256: "6d9213c65f1060116757a7c473247c60f3f7f332cac33dc417c9e362a9a13e4f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "2.6.0"
   webview_flutter_web:
     dependency: transitive
     description:
       name: webview_flutter_web
-      sha256: a9b17576fbf474ca529d2af2bb9736076eaf48a8db7b82bbb621efa621f42429
+      sha256: "545764e9500b22f28a0de71301a1085b8c66635a6b1be2072b80c578c663ce52"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0+3"
+    version: "0.2.2+2"
   webview_flutter_wkwebview:
     dependency: transitive
     description:
       name: webview_flutter_wkwebview
-      sha256: "5285e2a22199aaddf67b01114893c47a718dd2d989d78453dc0174d7386f88f6"
+      sha256: b4b42295b3aa91ed22ba6d3dd7de56efbb8f3ab3d6e41d8b1615d13537c7801d
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.1"
+    version: "3.9.2"
   win32:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -25,14 +25,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -139,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector
-      sha256: "1d2fde93dddf634a9c3c0faa748169d7ac0d83757135555707e52f02c017ad4f"
+      sha256: "84eaf3e034d647859167d1f01cfe7b6352488f34c1b4932635012b202014c25b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.5"
+    version: "1.0.1"
   file_selector_android:
     dependency: transitive
     description:
@@ -354,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: markdown
-      sha256: "39caf989ccc72c63e87b961851a74257141938599ed2db45fbd9403fee0db423"
+      sha256: acf35edccc0463a9d7384e437c015a3535772e09714cf60e07eeef3a15870dcd
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "7.1.1"
   matcher:
     dependency: transitive
     description:
@@ -514,10 +506,10 @@ packages:
     dependency: "direct main"
     description:
       name: simple_html_css
-      sha256: b290f005e819f80dfe4f361526877d75f21883db45b94a0196f1f35e4e0bc9ef
+      sha256: af730b15c0b37c97a14b6aeceabe68128855c4630dc500030f3c3e176e8fc57f
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1+1"
+    version: "4.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -703,10 +695,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "80d494c09849dc3f899d227a78c30c5b949b985ededf884cb3f3bcd39f4b447a"
+      sha256: ac0e3f4bf00ba2708c33fbabbbe766300e509f8c82dbd4ab6525039813f7e2fb
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.1"
+    version: "6.1.0"
   yaml:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   logging: ^1.0.2
 
-  simple_html_css: ^3.0.1+1
+  simple_html_css: ^4.0.0
 
 dev_dependencies:
   lint: ^2.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: faiadashu_example
 description: Gallery app for Faiadashu™
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
-  flutter: '>=3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   collection: ^1.16.0

--- a/faiabench/pubspec.yaml
+++ b/faiabench/pubspec.yaml
@@ -18,8 +18,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.1.0
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
-  flutter: '>=3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   code_text_field: ^1.0.2

--- a/faiadashu_online/pubspec.yaml
+++ b/faiadashu_online/pubspec.yaml
@@ -11,8 +11,8 @@ repository: https://github.com/tiloc/faiadashu
 issue_tracker: https://github.com/tiloc/faiadashu/issues
 
 environment:
-  sdk: '>=2.16.0 <3.0.0'
-  flutter: '>=2.10.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   faiadashu:

--- a/lib/questionnaires/view/src/webview_html.dart
+++ b/lib/questionnaires/view/src/webview_html.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import 'package:webview_flutter_web/webview_flutter_web.dart';
 
 Widget createWebView(String xhtml, {Key? key}) => _FullHtmlViewer(
       xhtml,
@@ -16,18 +15,18 @@ class _FullHtmlViewer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // required while web support is in preview
-    WebView.platform = WebWebViewPlatform();
-
     final dataUrl = Uri.dataFromString(
       xhtml,
       mimeType: 'text/html',
       encoding: Encoding.getByName('utf-8'),
-    ).toString();
+    );
+
+    final controller = WebViewController();
+    controller.loadRequest(dataUrl);
 
     return SizedBox.expand(
-      child: WebView(
-        initialUrl: dataUrl,
+      child: WebViewWidget(
+        controller: controller,
       ),
     );
   }

--- a/lib/questionnaires/view/src/webview_io.dart
+++ b/lib/questionnaires/view/src/webview_io.dart
@@ -27,11 +27,14 @@ class _FullHtmlViewer extends StatelessWidget {
       xhtml,
       mimeType: 'text/html',
       encoding: Encoding.getByName('utf-8'),
-    ).toString();
+    );
+
+    final controller = WebViewController();
+    controller.loadRequest(dataUrl);
 
     return SizedBox.expand(
-      child: WebView(
-        initialUrl: dataUrl,
+      child: WebViewWidget(
+        controller: controller,
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,8 +44,8 @@ dependencies:
   mime: ^1.0.4
   scrollable_positioned_list: ^0.3.2
   simple_html_css: ^4.0.0
-  webview_flutter: ^3.0.4
-  webview_flutter_web: ^0.1.0+3
+  webview_flutter: ^4.0.0
+  webview_flutter_web: ^0.2.0
 
 dev_dependencies:
   dart_code_metrics: ^4.15.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,8 @@ repository: https://github.com/tiloc/faiadashu
 issue_tracker: https://github.com/tiloc/faiadashu/issues
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
-  flutter: '>=3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: '>=3.7.0'
 
 dependencies:
   collection: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
 #    path: /Users/tilo/Projects/fhir/fhir
 #  fhir_path:
 #    path: /Users/tilo/Projects/fhir/fhir_path
-  file_selector: ^0.9.5
+  file_selector: ^1.0.0
   filesize: ^2.0.1
   flutter:
     sdk: flutter
@@ -39,11 +39,11 @@ dependencies:
     sdk: flutter
   intl: ^0.18.0
   logging: ^1.0.2
-  markdown: ^5.0.0
+  markdown: ^7.0.0
   meta: ^1.7.0
   mime: ^1.0.4
   scrollable_positioned_list: ^0.3.2
-  simple_html_css: ^3.0.1+1
+  simple_html_css: ^4.0.0
   webview_flutter: ^3.0.4
   webview_flutter_web: ^0.1.0+3
 


### PR DESCRIPTION
This PR updates the following packages:
* `file_selector`: Used for attachment questions
* `markdown`: For supporting the rendering-markdown extension
  * The Hot Beverage IG questionnaire has an example of this.
* `simple_html_css`: For rendering the rendering-xhtml extension
  * This is actually always used to render the text of all questions
* `webview_flutter` and `webview_flutter_web`: 
  * Used for rendering the Narrative panels toggled via the top-right button on the example app.
  * Updates the implementation to use the new API usage specified in the docs.

Additionally, this also raises the minimum versions of the Flutter and Dart SDKs.