### PR TITLE
Fix form flickering on response changes

### DIFF
--- a/lib/questionnaires/view/src/questionnaire_filler.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler.dart
@@ -127,7 +127,9 @@ class _QuestionnaireResponseFillerState
     _logger.trace('Enter build()');
 
     // Make sure to set this once only, or it may lead to flickering
-    builderFuture ??= widget._createQuestionnaireResponseModel(context: context);
+    if (builderFuture == null || _questionnaireResponseModel?.locale != Localizations.localeOf(context)) {
+      builderFuture = widget._createQuestionnaireResponseModel(context: context);
+    }
 
     return FutureBuilder<QuestionnaireResponseModel>(
       future: builderFuture,

--- a/lib/questionnaires/view/src/questionnaire_filler.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler.dart
@@ -65,6 +65,7 @@ class _QuestionnaireResponseFillerState
     extends State<QuestionnaireResponseFiller> {
   static final _logger = Logger(_QuestionnaireResponseFillerState);
 
+  Future<QuestionnaireResponseModel>? builderFuture;
   QuestionnaireResponseModel? _questionnaireResponseModel;
   VoidCallback? _handleQuestionnaireResponseModelChangeListenerFunction;
   // ignore: use_late_for_private_fields_and_variables
@@ -125,8 +126,11 @@ class _QuestionnaireResponseFillerState
   Widget build(BuildContext context) {
     _logger.trace('Enter build()');
 
+    // Make sure to set this once only, or it may lead to flickering
+    builderFuture ??= widget._createQuestionnaireResponseModel(context: context);
+
     return FutureBuilder<QuestionnaireResponseModel>(
-      future: widget._createQuestionnaireResponseModel(context: context),
+      future: builderFuture,
       builder: (context, snapshot) {
         switch (snapshot.connectionState) {
           case ConnectionState.active:


### PR DESCRIPTION
Fixes #75 

Creates QuestionnaireResponseModel only once across rebuilds of QuestionnaireFiller.

Apparently this was added recently in #49.

@hanny-ph I found the issue earlier while working on the package upgrades by chance.

Could you check on your side if with these changes we can still achieve what we were trying to do in #49?