### PR TITLE
Add date range validations

### DIFF
--- a/doc/sdc-capabilities.md
+++ b/doc/sdc-capabilities.md
@@ -224,7 +224,8 @@ Special support for 🇩🇰 Danish specification on patient feedback.
 Comprehensive support. Date picker with localized format.
 
 #### Extensions
-- (none)
+- minValue (Supports setting dynamic values via `cqf-expression` extension)
+- maxValue (Supports setting dynamic values via `cqf-expression` extension)
 
 ---
 ### dateTime
@@ -232,9 +233,15 @@ Comprehensive support. Date/Time picker with localized format.
 
 #### Extensions
 - sdc-questionnaire-initialExpression
+- minValue (Supports setting dynamic values via `cqf-expression` extension)
+- maxValue (Supports setting dynamic values via `cqf-expression` extension)
 
 ### time
 Comprehensive support. Time picker with localized format.
+
+#### Extensions
+- minValue (Supports setting dynamic values via `cqf-expression` extension)
+- maxValue (Supports setting dynamic values via `cqf-expression` extension)
 
 ### string, text
 Comprehensive support. Keyboard type can be hinted.

--- a/example/assets/instruments/sdc_demo.json
+++ b/example/assets/instruments/sdc_demo.json
@@ -648,12 +648,117 @@
             {
               "url": "http://hl7.org/fhir/StructureDefinition/entryFormat",
               "valueString": "MM/DD/YYYY"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/minValue",
+              "valueDate": "1960-01-01"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
+              "_valueDate": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                    "valueExpression": {
+                      "language": "text/fhirpath",
+                      "expression": "today()"
+                    }
+                  }
+                ]
+              }
             }
           ],
           "linkId": "4.2.b.5",
-          "text": "Enter your birthdate (MM/DD/YYYY)",
+          "text": "Enter your birthdate (MM/DD/YYYY) (Only for people born 1960~today)",
           "type": "date",
           "answerValueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/entryFormat",
+              "valueString": "MM/DD/YYYY HH:mm:ss"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/minValue",
+              "valueDateTime": "1980-01-01T00:00:00"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
+              "valueDateTime": "2030-01-01T00:00:00"
+            }
+          ],
+          "linkId": "4.2.b.5-1",
+          "text": "Enter your birth date and time (MM/DD/YYYY HH:mm:ss) (For people born 1980~2030)",
+          "type": "dateTime"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/entryFormat",
+              "valueString": "MM/DD/YYYY HH:mm:ss"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/minValue",
+              "_valueDateTime": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                    "valueExpression": {
+                      "language": "text/fhirpath",
+                      "expression": "now() - 20 years"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
+              "_valueDateTime": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                    "valueExpression": {
+                      "language": "text/fhirpath",
+                      "expression": "now()"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "linkId": "4.2.b.5-2",
+          "text": "Enter your birth date and time (MM/DD/YYYY HH:mm:ss) (For people born within the last 20 years)",
+          "type": "dateTime"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/entryFormat",
+              "valueString": "HH:mm:ss"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/minValue",
+              "valueTime": "04:00:00"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/maxValue",
+              "_valueTime": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/cqf-expression",
+                    "valueExpression": {
+                      "language": "text/fhirpath",
+                      "expression": "timeOfDay()"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "linkId": "4.2.b.5-3",
+          "text": "Enter your birth time (HH:mm:ss) (4AM to current time only)",
+          "type": "time"
         },
         {
           "extension": [

--- a/lib/l10n/src/fdash_localizations_ar.dart
+++ b/lib/l10n/src/fdash_localizations_ar.dart
@@ -45,12 +45,12 @@ class FDashLocalizationsAr extends FDashLocalizations {
 
   @override
   String validatorMinValue(String minValue) {
-    return 'أدخل رقم $minValue أو أعلى.';
+    return 'أدخل قيمة $minValue أو أعلى.';
   }
 
   @override
   String validatorMaxValue(String maxValue) {
-    return 'أدخل رقمًا يصل إلى $maxValue.';
+    return 'أدخل قيمة تصل إلى $maxValue.';
   }
 
   @override

--- a/lib/l10n/src/fdash_localizations_de.dart
+++ b/lib/l10n/src/fdash_localizations_de.dart
@@ -44,12 +44,12 @@ class FDashLocalizationsDe extends FDashLocalizations {
 
   @override
   String validatorMinValue(String minValue) {
-    return 'Eine Zahl ab $minValue eingeben.';
+    return 'Einen Wert ab $minValue eingeben.';
   }
 
   @override
   String validatorMaxValue(String maxValue) {
-    return 'Eine Zahl bis $maxValue eingeben.';
+    return 'Einen Wert bis $maxValue eingeben.';
   }
 
   @override

--- a/lib/l10n/src/fdash_localizations_en.dart
+++ b/lib/l10n/src/fdash_localizations_en.dart
@@ -45,12 +45,12 @@ class FDashLocalizationsEn extends FDashLocalizations {
 
   @override
   String validatorMinValue(String minValue) {
-    return 'Enter a number of $minValue or higher.';
+    return 'Enter a value of $minValue or higher.';
   }
 
   @override
   String validatorMaxValue(String maxValue) {
-    return 'Enter a number up to $maxValue.';
+    return 'Enter a value up to $maxValue.';
   }
 
   @override

--- a/lib/l10n/src/fdash_localizations_es.dart
+++ b/lib/l10n/src/fdash_localizations_es.dart
@@ -46,12 +46,12 @@ class FDashLocalizationsEs extends FDashLocalizations {
 
   @override
   String validatorMinValue(String minValue) {
-    return 'Introduzca un número de $minValue o superior.';
+    return 'Introduzca un valor de $minValue o superior.';
   }
 
   @override
   String validatorMaxValue(String maxValue) {
-    return 'Introduzca un número hasta $maxValue.';
+    return 'Introduzca un valor hasta $maxValue.';
   }
 
   @override

--- a/lib/l10n/src/fdash_localizations_ja.dart
+++ b/lib/l10n/src/fdash_localizations_ja.dart
@@ -45,12 +45,12 @@ class FDashLocalizationsJa extends FDashLocalizations {
 
   @override
   String validatorMinValue(String minValue) {
-    return '$minValue以上の数値を入力してください。';
+    return '$minValue以上の値を入力してください。';
   }
 
   @override
   String validatorMaxValue(String maxValue) {
-    return '$maxValueまでの数値を入力してください。';
+    return '$maxValueまでの値を入力してください。';
   }
 
   @override

--- a/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/datetime_answer_filler.dart
@@ -2,7 +2,7 @@ import 'package:faiadashu/fhir_types/fhir_types.dart';
 import 'package:faiadashu/l10n/l10n.dart';
 import 'package:faiadashu/questionnaires/questionnaires.dart';
 import 'package:fhir/r4.dart'
-    show FhirDate, FhirDateTime, QuestionnaireItemType, FhirTime;
+    show FhirDate, FhirDateTime, FhirTime;
 import 'package:flutter/material.dart';
 
 class DateTimeAnswerFiller extends QuestionnaireAnswerFiller {
@@ -34,7 +34,7 @@ class _DateTimeAnswerState extends QuestionnaireAnswerFillerState<FhirDateTime,
 }
 
 class _DateTimeInputControl extends AnswerInputControl<DateTimeAnswerModel> {
-  
+
   const _DateTimeInputControl(
     super.answerModel, {
     super.focusNode,


### PR DESCRIPTION
Closes #107 

- Adds support for minValue and maxValue extensions in date, time and dateTime items.
- Adds support for dynamic calculation of min/max time ranges via cqf-expression extensions.
- Updates SDC demo Questionnaire with examples of static and dynamic range validations.
- Updates SDC capabilities document.
- Adjusts min/maxValue validation messages to support both numbers and dates/times/datetimes.

## Notes

- According to the [SDC docs](https://build.fhir.org/ig/HL7/sdc/behavior.html#minValue), dynamic values for min/maxValue extensions can be done with the [cqf-calculatedValue](https://build.fhir.org/ig/HL7/sdc/behavior.html#cqf-calculatedValue) extension.
- Here we implement them with [cqf-expression](https://build.fhir.org/ig/HL7/sdc/behavior.html#cqf-expression) instead.
  - While cqf-expression doesn't explicitly state minValue and maxValue as recommended locations to use it, it does mention it is possible to use in other places.
  - I also believe the reference to cqf-calculatedValue in the min/maxValue docs may be mistaken, since the extension doesn't allow expressions like the ones mentioned in the docs, and only the name to some variable declared in an external library defined in a [cqf-library](https://build.fhir.org/ig/HL7/fhir-extensions/StructureDefinition-cqf-library.html) extension.