### PR TITLE
Fix onBeforePageChanged not called when jumping to the previous question

### DIFF
--- a/example/lib/custom_questionnaire_stepper_page.dart
+++ b/example/lib/custom_questionnaire_stepper_page.dart
@@ -108,7 +108,11 @@ class _CustomQuestionnaireStepperPageState
                 data: QuestionnaireStepperPageViewData(
                   controller: _controller,
                   onPageChanged: _onPageChanged,
-                  onBeforePageChanged: (currentItemModel, nextItemModel) async {
+                  onBeforePageChanged: (
+                    direction,
+                    currentItemModel,
+                    nextItemModel,
+                  ) async {
                     return BeforePageChangedData(canProceed: true);
                   },
                   onVisibleItemUpdated: (item) {

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -178,7 +178,10 @@ class QuestionnaireStepperPageViewController {
   }
 
   /// Back to the previous page in the `QuestionnaireStepperPageView`.
-  void previousPage({Duration? duration, Curve? curve}) {
+  Future<void> previousPage({
+    Duration? duration,
+    Curve? curve,
+  }) async {
     /// This will prevent racing issue
     if (_state?._hasRequestsRunning ?? false) {
       return;
@@ -188,10 +191,13 @@ class QuestionnaireStepperPageViewController {
       return;
     }
 
-    _state?._pageController.previousPage(
-      curve: curve ?? Curves.easeIn,
-      duration: duration ?? const Duration(milliseconds: 250),
-    );
+    final data = await _state?._onBeforePageChanged();
+    if (data?.canProceed ?? true) {
+      _state?._pageController.previousPage(
+        curve: curve ?? Curves.easeIn,
+        duration: duration ?? const Duration(milliseconds: 250),
+      );
+    }
   }
 
   /// Jump to specific page in the `QuestionnaireStepperPageView`.

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -47,7 +47,9 @@ class _QuestionnaireStepperPageViewState
   }
 
   /// Determines if we can proceed to the next page.
-  Future<BeforePageChangedData> _onBeforePageChanged() async {
+  Future<BeforePageChangedData> _onBeforePageChanged({
+    required QuestionnaireStepperDirection direction,
+  }) async {
     _hasRequestsRunning = true;
     final currentPage = _pageController.page!.round();
     final themeData = QuestionnaireTheme.of(context);
@@ -62,6 +64,7 @@ class _QuestionnaireStepperPageViewState
 
     if (_currentQuestionnaireItemFiller != null) {
       final data = await widget.data.onBeforePageChanged?.call(
+        direction,
         _currentQuestionnaireItemFiller!.fillerItemModel,
         nextPageFillerItem?.fillerItemModel,
       );
@@ -102,8 +105,6 @@ class _QuestionnaireStepperPageViewState
     return _QuestionnaireStepperPageViewInheritedWidget(
       data: widget.data,
       child: PageView.builder(
-        /// [PageView.scrollDirection] defaults to [Axis.horizontal].
-        /// Use [Axis.vertical] to scroll vertically.
         controller: _pageController,
         onPageChanged: _handleChangedPage,
         itemBuilder: (BuildContext context, int index) {
@@ -191,7 +192,9 @@ class QuestionnaireStepperPageViewController {
       return;
     }
 
-    final data = await _state?._onBeforePageChanged();
+    final data = await _state?._onBeforePageChanged(
+      direction: QuestionnaireStepperDirection.previous,
+    );
     if (data?.canProceed ?? true) {
       _state?._pageController.previousPage(
         curve: curve ?? Curves.easeIn,
@@ -262,8 +265,9 @@ class QuestionnaireStepperPageViewData {
   final ScrollPhysics? physics;
   final ValueChanged<int>? onPageChanged;
   final Future<BeforePageChangedData> Function(
-    FillerItemModel,
-    FillerItemModel?,
+    QuestionnaireStepperDirection direction,
+    FillerItemModel currentItemModel,
+    FillerItemModel? nextItemModel,
   )? onBeforePageChanged;
   final void Function(FillerItemModel?)? onVisibleItemUpdated;
 
@@ -276,4 +280,13 @@ class QuestionnaireStepperPageViewData {
   }) {
     this.controller = controller ?? QuestionnaireStepperPageViewController();
   }
+}
+
+/// Enum to define the direction of navigation in a questionnaire stepper.
+enum QuestionnaireStepperDirection {
+  /// Represents moving forward to the next question or section.
+  next,
+
+  /// Represents moving backward to the previous question or section.
+  previous,
 }

--- a/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper_page_view.dart
@@ -169,7 +169,9 @@ class QuestionnaireStepperPageViewController {
       return;
     }
 
-    final data = await _state?._onBeforePageChanged();
+    final data = await _state?._onBeforePageChanged(
+      direction: QuestionnaireStepperDirection.next,
+    );
     if (data?.canProceed ?? true) {
       _state?._pageController.nextPage(
         curve: curve ?? Curves.easeIn,


### PR DESCRIPTION
This PR fixes the bug about onBeforePageChanged not called when jumping to the previous question.