### PR TITLE
Resolve: "Questionnaire Item type boolean initial value is always marked as true"

### DIFF
--- a/lib/questionnaires/view/item/answer/src/boolean_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/boolean_answer_filler.dart
@@ -44,7 +44,7 @@ class _BooleanInputControl extends AnswerInputControl<BooleanAnswerModel> {
           focusNode: focusNode,
           value: (answerModel.isTriState)
               ? answerModel.value?.value
-              : (answerModel.value?.value != null),
+              : (answerModel.value?.value ?? false),
           activeColor:
               (answerModel.displayErrorText(FDashLocalizations.of(context)) !=
                       null)


### PR DESCRIPTION
## Summary of changes

Related to issue(s) #123 

- The issue was that after accepting a Tri-state boolean, it was handled as if `null` was `false` and everything else was `true`. That caused the bug that the initial value as `false` would be turned into a `true` value.

## Additional comments

None
