### PR TITLE
Fix QuestionnaireResponse population with scoring

### DIFF
--- a/lib/questionnaires/model/aggregation/src/total_score_aggregator.dart
+++ b/lib/questionnaires/model/aggregation/src/total_score_aggregator.dart
@@ -17,9 +17,10 @@ class TotalScoreAggregator extends Aggregator<FhirDecimal> {
   static final _logger = Logger(TotalScoreAggregator);
 
   late final QuestionItemModel? totalScoreItem;
-  TotalScoreAggregator(
-      {required FDashLocalizations localizations, bool autoAggregate = true,})
-      : super(
+  TotalScoreAggregator({
+    required FDashLocalizations localizations,
+    bool autoAggregate = true,
+  }) : super(
           FhirDecimal(0),
           localizations: localizations,
           autoAggregate: autoAggregate,
@@ -67,7 +68,9 @@ class TotalScoreAggregator extends Aggregator<FhirDecimal> {
       value = result;
     }
 
-    totalScoreItem.firstAnswerModel.populateFromExpression(result);
+    if (totalScoreItem.answerModels.isNotEmpty) {
+      totalScoreItem.firstAnswerModel.populateFromExpression(result);
+    }
 
     return result;
   }

--- a/lib/questionnaires/model/item/src/question_item_model.dart
+++ b/lib/questionnaires/model/item/src/question_item_model.dart
@@ -150,6 +150,7 @@ class QuestionItemModel extends ResponseItemModel {
   ///
   /// Returns null if not applicable (either question unanswered, or wrong type)
   FhirDecimal? get ordinalValue {
+    if (answerModels.isEmpty) return null;
     final answerModel = firstAnswerModel;
 
     return answerModel.isNotEmpty &&
@@ -326,11 +327,15 @@ class QuestionItemModel extends ResponseItemModel {
       // errors
       final initialValues = (questionnaireItem.initial ?? []).toList();
 
-      if ({QuestionnaireItemType.choice,QuestionnaireItemType.openChoice}.contains(questionnaireItem.type)) {
+      if ({QuestionnaireItemType.choice, QuestionnaireItemType.openChoice}
+          .contains(questionnaireItem.type)) {
         // Add answerOptions marked as initialSelected to array of initialValues
         final initialSelected = questionnaireItem.answerOption
-            ?.where((option) => option.initialSelected?.value == true && option.valueCoding != null)
-            .map((option) => QuestionnaireInitial(valueCoding: option.valueCoding));
+            ?.where((option) =>
+                option.initialSelected?.value == true &&
+                option.valueCoding != null)
+            .map((option) =>
+                QuestionnaireInitial(valueCoding: option.valueCoding));
         initialValues.addAll(initialSelected ?? []);
       }
 


### PR DESCRIPTION
Fixes #138 

- Apparently the `TotalScoreAggregator` runs concurrently during `QuestionnaireResponse` population.
- While the aggregator intends to simply read data to perform calculations, it does so by invoking the `firstAnswerModel` getter in `QuestionItemModel`, which causes it to add a new answer model to the item if one is not present already.
- There appears to be some sort of race condition which makes both answer population and score aggregation call `firstAnswerModel` and cause it to add more than a single answer model.
- The current fix basically avoids calling `firstAnswerModel` from `TotalScoreAggregator` if no answer models are defined yet.